### PR TITLE
Fix infinite rerender potential error

### DIFF
--- a/src/pages/tools/recruit.tsx
+++ b/src/pages/tools/recruit.tsx
@@ -137,7 +137,7 @@ const Recruit: NextPage = () => {
   useEffect(() => {
     setShowPotentials(_showPotentials);
     setCompact(_compact);
-  })
+  }, [])
 
   return (
     <Layout tab="/tools" page="/recruit">


### PR DESCRIPTION
Fixes a potential infinite rerender in the recruit component caused by a useEffect with no dependencies.