### PR TITLE
Reset op lvl after promotion

### DIFF
--- a/src/pages/planner/goals.tsx
+++ b/src/pages/planner/goals.tsx
@@ -70,7 +70,12 @@ const Goals: NextPage = () => {
         operatorsJson[goal.operatorId as keyof typeof operatorsJson];
       switch (goal.category) {
         case OperatorGoalCategory.Elite:
+          const prevPromotion = ops[goal.operatorId].promotion;
           ops[goal.operatorId].promotion = Math.max(goal.eliteLevel, op.promotion);
+          // reset Operator level
+          if (goal.eliteLevel > prevPromotion) {
+            ops[goal.operatorId].level = 1;
+          }
           break;
         case OperatorGoalCategory.SkillLevel:
           ops[goal.operatorId].skillLevel = Math.max(goal.skillLevel, op.skillLevel);

--- a/src/util/changeOperator.ts
+++ b/src/util/changeOperator.ts
@@ -648,8 +648,13 @@ export const changePotential = (op: Operator, value: number) => {
 
 export const changePromotion = (op: Operator, value: number) => {
   if (!op.owned) return op;
+  const prevPromotion = op.promotion;
   op.promotion = minMax(0, value, MAX_PROMOTION_BY_RARITY[op.rarity])
   op = changeLevel(op, op.level);
+  // reset Operator level
+  if (value > prevPromotion) {
+    op.level = 1;
+  }
   op = changeSkillLevel(op, op.skillLevel);
   if (value !== 2) {
     op.module = [];


### PR DESCRIPTION
Made it so that the operator level resets to 1 when the operator is promoted, either by clicking a higher promotion icon in the collection screen or by completing an Elite goal in the planner.