### PR TITLE
Add github action to automate game data updates

### DIFF
--- a/.github/workflows/update-game-data.yml
+++ b/.github/workflows/update-game-data.yml
@@ -2,7 +2,7 @@ name: Update Game Data
 on:
   workflow_dispatch:
   schedule:
-    - cron: '37 * * * *'
+    - cron: '37 0 * * *'
 
 jobs:
   run_update_scripts:
@@ -12,7 +12,7 @@ jobs:
       # see if the branch already exists
       - name: Check for existing branch
         run: |
-          if git ls-remote --heads --quiet --exit-code refs/heads/actions/update-game-data > /dev/null; then
+          if git ls-remote --heads --quiet --exit-code ${{ github.repositoryUrl }} refs/heads/actions/update-game-data > /dev/null; then
             echo "TARGET_BRANCH=actions/update-game-data" >> $GITHUB_ENV
           else
             echo "TARGET_BRANCH=main" >> $GITHUB_ENV
@@ -22,7 +22,7 @@ jobs:
         with:
           ref: ${{ env.TARGET_BRANCH }}
       # create the branch if it didn't exist
-      - run: git checkout -B actions/update-game-data
+      - run: git checkout -b actions/update-game-data
         if: env.TARGET_BRANCH == 'main'
       # set up the project
       - uses: actions/setup-node@v4

--- a/.github/workflows/update-game-data.yml
+++ b/.github/workflows/update-game-data.yml
@@ -1,0 +1,58 @@
+name: Update Game Data
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '37 * * * *'
+
+jobs:
+  run_update_scripts:
+    name: Run update scripts
+    runs-on: ubuntu-latest
+    steps:
+      # see if the branch already exists
+      - name: Check for existing branch
+        run: |
+          if git ls-remote --heads --quiet --exit-code refs/heads/actions/update-game-data > /dev/null; then
+            echo "TARGET_BRANCH=actions/update-game-data" >> $GITHUB_ENV
+          else
+            echo "TARGET_BRANCH=main" >> $GITHUB_ENV
+          fi
+      # checkout the branch if it does, otherwise main
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+      # create the branch if it didn't exist
+      - run: git checkout -B actions/update-game-data
+        if: env.TARGET_BRANCH == 'main'
+      - name: Cache submodules
+        id: cache-submodules
+        uses: actions/cache@v3
+        with:
+          key: '${{ runner.os }}-submodules'
+          path: |
+            scripts/ArknightsGameData
+            scripts/ArknightsGameData_Yostar
+      # set up the project
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: git submodule update --init --depth=1
+      # run update scripts
+      - run: yarn update:all
+      # commit changes and PR, but only if krooster data files changed (i.e. skip submodule-only updates)
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --ignore-submodules --cached --quiet; then
+            VERSION_MESSAGE=$(git submodule --quiet foreach git log -1 --pretty='%h %s%N%-C()')
+            git commit -m "Update game data." -m "$VERSION_MESSAGE"
+            git push origin actions/update-game-data
+            gh pr create -B main -H actions/update-game-data --fill \
+              || gh pr edit -H actions/update-game-data --body "$VERSION_MESSAGE"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-game-data.yml
+++ b/.github/workflows/update-game-data.yml
@@ -24,21 +24,23 @@ jobs:
       # create the branch if it didn't exist
       - run: git checkout -B actions/update-game-data
         if: env.TARGET_BRANCH == 'main'
-      - name: Cache submodules
-        id: cache-submodules
-        uses: actions/cache@v3
-        with:
-          key: '${{ runner.os }}-submodules'
-          path: |
-            scripts/ArknightsGameData
-            scripts/ArknightsGameData_Yostar
       # set up the project
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version-file: .nvmrc
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
-      - run: git submodule update --init --depth=1
+      - run: |
+          git submodule init scripts/
+          git clone -n --depth=1 $(git config submodule."scripts/ArknightsGameData".url) scripts/ArknightsGameData
+          cd scripts/ArknightsGameData
+          git sparse-checkout set zh_CN/gamedata/excel/
+          cd -
+          git clone -n --depth=1 $(git config submodule."scripts/ArknightsGameData_YoStar".url) scripts/ArknightsGameData_YoStar
+          cd scripts/ArknightsGameData_YoStar
+          git sparse-checkout set en_US/gamedata/excel/
+          cd -
+          git submodule update --init --remote --depth=1 --force scripts/
       # run update scripts
       - run: yarn update:all
       # commit changes and PR, but only if krooster data files changed (i.e. skip submodule-only updates)
@@ -50,9 +52,42 @@ jobs:
           if ! git diff --ignore-submodules --cached --quiet; then
             VERSION_MESSAGE=$(git submodule --quiet foreach git log -1 --pretty='%h %s%N%-C()')
             git commit -m "Update game data." -m "$VERSION_MESSAGE"
-            git push origin actions/update-game-data
+            git push origin actions/update-game-data --force
             gh pr create -B main -H actions/update-game-data --fill \
-              || gh pr edit -H actions/update-game-data --body "$VERSION_MESSAGE"
+              || gh pr edit --body "$VERSION_MESSAGE"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  update-images:
+    name: Update image assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: main-repo
+          sparse-checkout: scripts
+      - uses: actions/checkout@v4
+        with:
+          repository: PuppiizSunniiz/Arknight-Images
+          path: Arknight-Images
+          sparse-checkout: |
+            skills
+            avatars
+            characters
+            equip
+            items
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: main-repo/.nvmrc
+          cache: 'yarn'
+          cache-dependency-path: main-repo/yarn.lock
+      - name: Run images script
+        run: cd main-repo && yarn install --frozen-lockfile && yarn update:images
+      - name: Sync to S3
+        run: |
+          cd main-repo/public/img
+          aws s3 sync --size-only . s3://krooster-test/images/
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-2'

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "next:start": "next start",
     "lint": "next lint",
     "server": "yarn next:build && NODE_ENV=production node server.js",
-    "update:all": "git submodule update --remote && node ./scripts/operators.mjs && node ./scripts/images.mjs && node ./scripts/skins.mjs && node ./scripts/recruit.mjs && node ./scripts/items.mjs",
+    "update:images": "node ./scripts/images.mjs",
+    "update:all": "git submodule update --remote && node ./scripts/operators.mjs && node ./scripts/skins.mjs && node ./scripts/recruit.mjs && node ./scripts/items.mjs",
     "update:operators": "git submodule update --remote && node ./scripts/operators.mjs",
-    "update:images": "git submodule update --remote && node ./scripts/images.mjs",
     "update:skins": "git submodule update --remote && node ./scripts/skins.mjs",
     "update:items": "git submodule update --remote && node ./scripts/items.mjs",
     "update:recruit": "git submodule update --remote && node ./scripts/recruit.mjs"

--- a/scripts/images.mjs
+++ b/scripts/images.mjs
@@ -9,38 +9,38 @@ const ACESHIP_ROOT = path.join(__dirname, "../../Arknight-Images");
 const tasks = [
   {
     sourceDir: path.join(ACESHIP_ROOT, "skills"),
-    destDir: "public\\img\\skills",
+    destDir: "public/img/skills",
     filter: (filename) => filename.endsWith(".png") && filename.startsWith("skchr_"),
     replace: (filename) => filename.replace(/^skill_icon_/, ""),
   },
   {
     sourceDir: path.join(ACESHIP_ROOT, "avatars"),
-    destDir: "public\\img\\avatars",
+    destDir: "public/img/avatars",
     filter: (filename) => /^char_.*\.png$/.test(filename),
   },
   {
     sourceDir: path.join(ACESHIP_ROOT, "characters"),
-    destDir: "public\\img\\characters",
+    destDir: "public/img/characters",
     filter: (filename) => /^char_.*\.png$/.test(filename),
   },
   {
     sourceDir: path.join(ACESHIP_ROOT, "equip/icon"),
-    destDir: "public\\img\\equip",
-    filter: (filename) => filename.endsWith(".png"),
+    destDir: "public/img/equip",
+    filter: (filename) => filename.endsWith(".png") && filename !== 'original.png',
   },
   {
     sourceDir: path.join(ACESHIP_ROOT, "equip/stage"),
-    destDir: "public\\img\\equip",
+    destDir: "public/img/equip",
     filter: (filename) => filename.endsWith(".png"),
   },
   {
     sourceDir: path.join(ACESHIP_ROOT, "equip/type"),
-    destDir: "public\\img\\equip",
+    destDir: "public/img/equip",
     filter: (filename) => filename.endsWith(".png"),
   },
   {
     sourceDir: path.join(ACESHIP_ROOT, "items"),
-    destDir: "public\\img\\items",
+    destDir: "public/img/items",
     filter: (filename) => filename.endsWith(".png"),
   },
 ];
@@ -64,7 +64,7 @@ const upload = async (existingFilePaths, task) => {
       const _filename = replaceFn ? replaceFn(filename) : filename;
       const targetFilePath = path.join(destDir, _filename);
       if (targetFilePath && !existingFilePaths.has(_filename)) {
-        console.log(`images: "${targetFilePath}" not found in storage, saving...`);
+        // console.log(`images: "${targetFilePath}" not found in storage, saving...`);
         const sourceFilePath = path.join(sourceDir, filename);
         //console.table({sourceFilePath, targetFilePath});
         await fs.copyFile(sourceFilePath, targetFilePath);
@@ -80,17 +80,18 @@ const uploadAllImages = async () => {
     const uploadCounts = await Promise.all(
       tasks.map(async (task) => {
         // first iterate through all images in the image directory
+        await fs.mkdir(task.destDir, { recursive: true });
         const rawFileNames = await fs.readdir(task.destDir, { withFileTypes: true });
         const existingImageIDs = new Set();
         rawFileNames.forEach((value) => existingImageIDs.add(value));
 
-        console.log(`images: found ${existingImageIDs.size} existing images in ${task.destDir}.`);
+        // console.log(`images: found ${existingImageIDs.size} existing images in ${task.destDir}.`);
 
-        upload(existingImageIDs, task);
+        return upload(existingImageIDs, task);
       })
     );
     const totalUploadCount = uploadCounts.reduce((acc, cur) => acc + cur, 0);
-    console.log(`images: uploaded ${totalUploadCount} new files, done.`);
+    console.log(`images: found ${totalUploadCount} total files, done.`);
   } catch (e) {
     console.error(e);
   }

--- a/scripts/images.mjs
+++ b/scripts/images.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ACESHIP_ROOT = path.join(__dirname, "../../Arknight-Images");
 
-/**@type {Array<{ sourceDir: string, destDir: string, replace?: (filename: string) => string, filter?: (filename: string) => boolean}} */
+/**@type {Array<{ sourceDir: string, destDir: string, replace?: (filename: string) => string, filter?: (filename: string) => boolean}>} */
 const tasks = [
   {
     sourceDir: path.join(ACESHIP_ROOT, "skills"),

--- a/scripts/items.mjs
+++ b/scripts/items.mjs
@@ -2,16 +2,14 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
-import enItemTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/item_table.json" assert { type: "json" };
-import cnBuildingData from "./ArknightsGameData/zh_CN/gamedata/excel/building_data.json" assert { type: "json" };
-import cnItemTable from "./ArknightsGameData/zh_CN/gamedata/excel/item_table.json" assert { type: "json" };
+import enItemTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/item_table.json" with { type: "json" };
+import cnBuildingData from "./ArknightsGameData/zh_CN/gamedata/excel/building_data.json" with { type: "json" };
+import cnItemTable from "./ArknightsGameData/zh_CN/gamedata/excel/item_table.json" with { type: "json" };
 
 const unofficialItemNameTranslations = {
-  mod_update_token_1: "Supplementary Data Bar",
-  mod_update_token_2: "Supplementary Data Instrument",
-  30155: "Sintered Core Crystals",
-  31063: "Transmuted Salt Cluster",
-  31064: "Transmuted Salt Block",
+  30165: "Biphasic Enantiomorphic Medium",
+  31093: "Pseudocondensation Nucleus",
+  31094: "Chiral Refractor",
 };
 
 const getEnglishItemName = (itemId) => {

--- a/scripts/operators.mjs
+++ b/scripts/operators.mjs
@@ -2,14 +2,14 @@
 import path from "path";
 import { fileURLToPath } from "url";
 
-import enCharacterPatchTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/char_patch_table.json" assert { type: "json" };
-import enCharacterTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/character_table.json" assert { type: "json" };
-import enSkillTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/skill_table.json" assert { type: "json" };
-import enUniequipTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/uniequip_table.json" assert { type: "json" };
-import cnCharacterPatchTable from "./ArknightsGameData/zh_CN/gamedata/excel/char_patch_table.json" assert { type: "json" };
-import cnCharacterTable from "./ArknightsGameData/zh_CN/gamedata/excel/character_table.json" assert { type: "json" };
-import cnSkillTable from "./ArknightsGameData/zh_CN/gamedata/excel/skill_table.json" assert { type: "json" };
-import cnUniequipTable from "./ArknightsGameData/zh_CN/gamedata/excel/uniequip_table.json" assert { type: "json" };
+import enCharacterPatchTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/char_patch_table.json" with { type: "json" };
+import enCharacterTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/character_table.json" with { type: "json" };
+import enSkillTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/skill_table.json" with { type: "json" };
+import enUniequipTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/uniequip_table.json" with { type: "json" };
+import cnCharacterPatchTable from "./ArknightsGameData/zh_CN/gamedata/excel/char_patch_table.json" with { type: "json" };
+import cnCharacterTable from "./ArknightsGameData/zh_CN/gamedata/excel/character_table.json" with { type: "json" };
+import cnSkillTable from "./ArknightsGameData/zh_CN/gamedata/excel/skill_table.json" with { type: "json" };
+import cnUniequipTable from "./ArknightsGameData/zh_CN/gamedata/excel/uniequip_table.json" with { type: "json" };
 
 const enPatchCharacters = enCharacterPatchTable.patchChars;
 const cnPatchCharacters = cnCharacterPatchTable.patchChars;

--- a/scripts/recruit.mjs
+++ b/scripts/recruit.mjs
@@ -4,8 +4,8 @@ import { fileURLToPath } from "url";
 
 import { Combination } from "js-combinatorics";
 
-import characterTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/character_table.json" assert { type: "json" };
-import gachaTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/gacha_table.json" assert { type: "json" };
+import characterTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/character_table.json" with { type: "json" };
+import gachaTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/gacha_table.json" with { type: "json" };
 
 export function professionToClass(profession) {
   switch (profession) {

--- a/scripts/skins.mjs
+++ b/scripts/skins.mjs
@@ -2,9 +2,9 @@
 import path from "path";
 import { fileURLToPath } from "url";
 
-import enSkinTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/skin_table.json" assert { type: "json" };
-import cnSkinTable from "./ArknightsGameData/zh_CN/gamedata/excel/skin_table.json" assert { type: "json" };
-import cnCharacterTable from "./ArknightsGameData/zh_CN/gamedata/excel/character_table.json" assert { type: "json" };
+import enSkinTable from "./ArknightsGameData_YoStar/en_US/gamedata/excel/skin_table.json" with { type: "json" };
+import cnSkinTable from "./ArknightsGameData/zh_CN/gamedata/excel/skin_table.json" with { type: "json" };
+import cnCharacterTable from "./ArknightsGameData/zh_CN/gamedata/excel/character_table.json" with { type: "json" };
 
 const isOperator = (charId) => {
   const operator = cnCharacterTable[charId];


### PR DESCRIPTION
This adds a workflow two GH action jobs.

The first pulls the ArknightsGameData submodules, runs the update scripts (except for images), and PRs if there's any changes to the data files ([example](https://github.com/wizjany/ak-roster/pull/8)). If there's more changes before the PR is accepted, the action will re-use the existing branch and PR and force-push the newly updated files.

The second pulls the aceship image repo, runs the images script, and syncs the result to s3 ([example run](https://github.com/wizjany/ak-roster/actions/runs/15057947258/job/42327617531)). Sync is configured to do nothing if image sizes don't change ([example run](https://github.com/wizjany/ak-roster/actions/runs/15058846238/job/42330029918)).

There's also some misc fixes and tweaks. The `update:all` script now excludes images, since those use a separate data source. I also fixed a typing error and some v8 deprecations (assert -> with). The new optical items have unofficial translations (from terra wiki).

Before merging, the s3 bucket name/path need to be updated (and region), and an IAM role with bucket access and keys needs to be created and the keys added to the repo secrets. The cron schedule should be adjusted as desired (once a day probably is enough?).