### PR TITLE
Fix two bounds issues when adding planner goals.

### DIFF
--- a/src/components/planner/goals/PlannerGoalAdd.tsx
+++ b/src/components/planner/goals/PlannerGoalAdd.tsx
@@ -209,7 +209,7 @@ const PlannerGoalAdd = (props: Props) => {
         setIsEdit(false);
       }
     },
-    [goals, roster, defaultOperatorObject, opData, setOpData, setIsEdit, setCurrentOp, setGoalBuilder, selectedGroup]
+    [goals, roster, opData, setOpData, setIsEdit, setCurrentOp, setGoalBuilder, selectedGroup]
   );
 
   const addGroup = (groupName: string) => {
@@ -299,7 +299,7 @@ const PlannerGoalAdd = (props: Props) => {
     const max_to = MAX_LEVEL_BY_RARITY[opData!.rarity][elite_to];
     setGoalBuilder((prev) => ({
       ...prev,
-      level_from: clamp(1, prev.level_from ?? level_to, elite_from === elite_to ? level_to : max_from),
+      level_from: clamp(1, prev.level_from ?? level_to, elite_from === elite_to ? clamp(1, level_to, max_to) : max_from),
       level_to: clamp(1, level_to, max_to),
     }));
   };
@@ -370,7 +370,7 @@ const PlannerGoalAdd = (props: Props) => {
     if (!opData?.moduleData?.find((mod) => mod.moduleId === moduleId)) return;
 
     const modules_from = { ...(goalBuilder.modules_from as Record<string, number>) };
-    modules_from[moduleId] = clamp(0, modules_from[moduleId], newModuleLevel);
+    modules_from[moduleId] = clamp(0, modules_from[moduleId] || 0, newModuleLevel);
     const modules_to = { ...(goalBuilder.modules_to as Record<string, number>) };
     modules_to[moduleId] = clamp(0, newModuleLevel, 3);
     setGoalBuilder((prev) => ({

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -415,8 +415,8 @@ const Home: NextPage = () => {
                   <path d="M9.09586 8.42361L5.01581 10.7122V7.2793L9.09586 8.42361Z" fill="#87879B"></path>
                   <path d="M9.37436 9.35522L8.46425 11.5391L6.03729 11.2271L9.37436 9.35522Z" fill="#E8E8F2"></path>
                   <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
+                    fillRule="evenodd"
+                    clipRule="evenodd"
                     d="M14.097 11.156L9.48358 11.5209L10.5482 8.96631L14.097 11.156Z"
                     fill="#87879B"
                   ></path>


### PR DESCRIPTION
First was modules_from defaulting to NaN, causing the goal to disappear. Second was setting level_from to level_to before level_to was clamped, allowing a negative level_from.

Also fix a jsx compilation warning in the svg on the front page, and a React lint warning about callback dependencies.