### PR TITLE
Switch GH action from ssh to https.

### DIFF
--- a/.github/workflows/update-game-data.yml
+++ b/.github/workflows/update-game-data.yml
@@ -12,7 +12,7 @@ jobs:
       # see if the branch already exists
       - name: Check for existing branch
         run: |
-          if git ls-remote --heads --quiet --exit-code ${{ github.repositoryUrl }} refs/heads/actions/update-game-data > /dev/null; then
+          if git ls-remote --heads --quiet --exit-code ${{ github.server_url }}/${{ github.repository }} refs/heads/actions/update-game-data > /dev/null; then
             echo "TARGET_BRANCH=actions/update-game-data" >> $GITHUB_ENV
           else
             echo "TARGET_BRANCH=main" >> $GITHUB_ENV


### PR DESCRIPTION
Actions runners apparently can't access the repository over the default context repository url, which uses ssh (git://).

This doesn't generally change behavior but it saves a minute or more of git timing out.