### PR TITLE
Filters: Pools, SL, Mastery tweaks & fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "server": "yarn next:build && NODE_ENV=production node server.js",
     "update:images": "node ./scripts/images.mjs",
-    "update:all": "git submodule update --remote && node ./scripts/operators.mjs && node ./scripts/skins.mjs && node ./scripts/recruit.mjs && node ./scripts/items.mjs",
+    "update:all": "git submodule update --remote && node ./scripts/recruit.mjs && node ./scripts/operators.mjs && node ./scripts/skins.mjs && node ./scripts/items.mjs",
     "update:operators": "git submodule update --remote && node ./scripts/operators.mjs",
     "update:skins": "git submodule update --remote && node ./scripts/skins.mjs",
     "update:items": "git submodule update --remote && node ./scripts/items.mjs",

--- a/scripts/images.mjs
+++ b/scripts/images.mjs
@@ -43,6 +43,11 @@ const tasks = [
     destDir: "public/img/items",
     filter: (filename) => filename.endsWith(".png"),
   },
+  {
+    sourceDir: path.join(ACESHIP_ROOT, "ui/subclass"),
+    destDir: "public/img/subclass",
+    filter: (filename) => filename.endsWith(".png"),
+  },
 ];
 
 const upload = async (existingFilePaths, task) => {

--- a/src/components/data/collate/FilterDialog.tsx
+++ b/src/components/data/collate/FilterDialog.tsx
@@ -23,6 +23,7 @@ import Promotion from "../input/Select/Promotion";
 import PropertyLevel from "../input/Select/PropertyLevel";
 import FavoriteFilter from "./filter/FavoriteFilter";
 import PoolsFilter from "./filter/PoolsFilter";
+import MasteryFilter from "./filter/MasteryFilter";
 
 interface Props {
   filter: Filters;
@@ -117,12 +118,12 @@ const FilterDialog = memo((props: Props) => {
               <PropertyLevel property="module"
                 value={[...filter.MODULELEVEL]} onChange={(value) => toggleFilter("MODULELEVEL", value)} />
             </Select>
-            <Select title="Skill Level" nobg sx={{ gridColumn: { xs: "1 / -1", sm: "span 4" } }}>
-              <PropertyLevel property="skill" fullWidth min={1} max={7}
+            <Select title="Skill Level" nobg sx={{ gridColumn: "span 2" }}>
+              <PropertyLevel property="skill" fullWidth min={1} max={7} step={3}
                 value={[...filter.SKILLLEVEL]} onChange={(value) => toggleFilter("SKILLLEVEL", value)} />
             </Select>
-            <Select title="Mastery" nobg sx={{ gridColumn: { xs: "1 / -1", sm: "span 3" } }}>
-              <PropertyLevel property="mastery"
+            <Select title="Mastery" nobg sx={{ gridColumn: { xs: "1 / -1", sm: "span 5" } }}>
+              <MasteryFilter property="mastery"
                 value={[...filter.MASTERY]} onChange={(value) => toggleFilter("MASTERY", value)} />
             </Select>
             <Select title="Pools" nobg sx={{whiteSpace: "nowrap", gridColumn: "1 / -1" }}>

--- a/src/components/data/collate/filter/MasteryFilter.tsx
+++ b/src/components/data/collate/filter/MasteryFilter.tsx
@@ -1,0 +1,89 @@
+import React, { memo, useContext } from "react";
+import { Box, ToggleButton, ToggleButtonGroup, ToggleButtonGroupProps } from "@mui/material";
+import { DisabledContext } from "../../input/Select/SelectGroup";
+import Image from "components/base/Image";
+import imageBase from "util/imageBase";
+
+interface Props extends Omit<ToggleButtonGroupProps, "onChange" | "size"> {
+  min?: number;
+  max?: number;
+  size?: number;
+  onChange: (PropertyLevel: number) => void;
+}
+const MasteryLevel = memo((props: Props) => {
+  const { value, min = 0, max = 5, size = 32, disabled: _disabled = false, sx, onChange, ...rest } = props;
+
+  const disabled = useContext(DisabledContext) || _disabled;
+
+  const path = "/rank/m-";
+
+  return (
+    <ToggleButtonGroup
+      value={value}
+      aria-label={`Mastery Level`}
+      disabled={disabled}
+      sx={{
+        display: "flex",
+        borderRadius: 1,
+        flexWrap: "nowrap",
+        gap: 0,
+        ...sx,
+      }}
+      {...rest}
+    >
+      {[...Array(max + 1).keys()]
+        .filter((n) => min <= n && n <= max)
+        .map((n) => {
+          const backLayerCount = n > 3 ? n - 3 : 0; // 4 → 1 layer, 5 → 2 layer
+          const shift = 4;
+          const spread = backLayerCount * shift;
+          const halfSpread = spread / 2;
+          return (
+
+            <ToggleButton
+              key={n}
+              value={n}
+              onChange={() => onChange(n)}
+              sx={{
+                p: 1,
+                "&:not(._):not(._)": {
+                  borderRadius: 1,
+                },
+                "& img": { filter: "drop-shadow(0px 0px 2px #000)" },
+              }}
+            >
+              <Box sx={{ position: "relative", width: size, height: size, }} >
+                <Image width={size} height={size} src={`${imageBase}${path}${n - backLayerCount}.webp`} alt={`Rank ${n}`}
+                  sx={{
+                    position: "absolute",
+                    top: halfSpread,
+                    left: -halfSpread,
+                    zIndex: backLayerCount + 1,
+                  }} />
+                {Array.from({ length: backLayerCount }).map((_, i) => {
+                  const offset = i * shift - halfSpread;
+                  return (
+                  <Image
+                    key={`back-${i}`}
+                    width={size}
+                    height={size}
+                    src={`${imageBase}${path}${n - backLayerCount}.webp`}
+                    alt={`Background Layer ${i + 1}`}
+                    style={{
+                      position: "absolute",
+                      top: offset,
+                      left: -offset,
+                      zIndex: i + 1,
+                      opacity: 0.7,
+                    }}
+                  />
+                )})}
+              </Box>
+            </ToggleButton>
+          )
+        })}
+    </ToggleButtonGroup>
+  );
+});
+MasteryLevel.displayName = "Property Level";
+export default MasteryLevel;

--- a/src/components/data/collate/filter/PoolsFilter.tsx
+++ b/src/components/data/collate/filter/PoolsFilter.tsx
@@ -1,7 +1,7 @@
 import { Box, ToggleButton, ToggleButtonGroup, ToggleButtonGroupProps } from "@mui/material";
 import React from "react";
 
-const poolsList = ["Standard", "Limited", "Kernel", "Kernel CN", "Recruitment", "Free"];
+const poolsList = ["Standard", "Limited", "Free", "Kernel", "Recruitment","Kernel CN" ];
 
 interface Props extends Omit<ToggleButtonGroupProps, "onChange"> {
   onChange: (value: string) => void;
@@ -14,8 +14,9 @@ const PoolsFilter = (props: Props) => {
     <ToggleButtonGroup
       value={value}
       sx={{
-        display: "grid",
-        gridTemplateColumns: { xs: "repeat(4, 1fr)", sm: "repeat(8, 1fr)" },
+        display: "flex",
+        flexWrap: "wrap",
+        justifyContent: {xs: "center", sm: "flex-start"},
         width: "100%",
         gap: 0.5,
       }}

--- a/src/components/data/collate/filter/PoolsFilter.tsx
+++ b/src/components/data/collate/filter/PoolsFilter.tsx
@@ -1,7 +1,7 @@
 import { Box, ToggleButton, ToggleButtonGroup, ToggleButtonGroupProps } from "@mui/material";
 import React from "react";
 
-const poolsList = ["Standard", "Limited", "Kernel", "Kernel CN", "Free"];
+const poolsList = ["Standard", "Limited", "Kernel", "Kernel CN", "Recruitment", "Free"];
 
 interface Props extends Omit<ToggleButtonGroupProps, "onChange"> {
   onChange: (value: string) => void;

--- a/src/components/data/input/Select/PropertyLevel.tsx
+++ b/src/components/data/input/Select/PropertyLevel.tsx
@@ -7,12 +7,13 @@ import imageBase from "util/imageBase";
 interface Props extends Omit<ToggleButtonGroupProps, "onChange" | "size"> {
   min?: number;
   max?: number;
+  step?: number;
   size?: number;
   onChange: (PropertyLevel: number) => void;
   property: string;
 }
 const PropertyLevel = memo((props: Props) => {
-  const { value, min = 0, max = 3, size = 32, disabled: _disabled = false, sx, onChange, property = "skill", ...rest } = props;
+  const { value, min = 0, max = 3, step = 1, size = 32, disabled: _disabled = false, sx, onChange, property = "skill", ...rest } = props;
 
   const disabled = useContext(DisabledContext) || _disabled;
 
@@ -21,7 +22,7 @@ const PropertyLevel = memo((props: Props) => {
       case "mastery": return "/rank/m-";
       case "module": return "/equip/img_stg";
       case "skill": return "/rank/";
-      default: return "/rank/m-";
+      default: return "/rank/";
     }
   }
 
@@ -39,7 +40,7 @@ const PropertyLevel = memo((props: Props) => {
       }}
       {...rest}
     >
-      {[...Array(max + 1).keys()]
+      {[...Array(Math.floor((max - min) / step) + 1)].map((_, i) => min + i * step)
         .filter((n) => min <= n && n <= max)
         .map((n) => (
           <ToggleButton

--- a/src/data/operators.json
+++ b/src/data/operators.json
@@ -8,7 +8,8 @@
     "branch": "Medic",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Free",
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -31,7 +32,7 @@
     "branch": "Dreadnought",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -54,7 +55,8 @@
     "branch": "Executor",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Free",
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -77,7 +79,7 @@
     "branch": "Marksman",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -147,7 +149,7 @@
     "branch": "Protector",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -170,7 +172,7 @@
     "branch": "Ritualist",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -192,9 +194,7 @@
     "class": "Vanguard",
     "branch": "Pioneer",
     "isCnOnly": true,
-    "pools": [
-      "Standard"
-    ],
+    "pools": [],
     "skillData": [],
     "moduleData": [],
     "potentials": [
@@ -216,7 +216,7 @@
     "branch": "Pioneer",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -239,7 +239,7 @@
     "branch": "Protector",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -262,7 +262,7 @@
     "branch": "Marksman",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -285,7 +285,8 @@
     "branch": "Core",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Free",
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -308,7 +309,8 @@
     "branch": "Splash",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Free",
+      "Recruitment"
     ],
     "skillData": [],
     "moduleData": [],
@@ -332,7 +334,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -462,7 +467,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -592,7 +599,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -722,7 +732,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -852,7 +865,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -982,7 +997,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -1112,7 +1128,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -1242,7 +1261,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -1372,7 +1393,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -1501,7 +1525,8 @@
     "branch": "Marksman",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Free",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -1631,7 +1656,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -1761,7 +1789,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -1891,7 +1922,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -2021,7 +2055,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -2151,7 +2187,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -2281,7 +2320,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -2642,7 +2683,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -3003,7 +3046,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -3364,7 +3409,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -3725,7 +3772,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -4446,7 +4494,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -4807,7 +4858,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -5168,7 +5221,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -5529,7 +5584,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -5890,7 +5947,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -6251,7 +6310,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -6612,7 +6673,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -6973,7 +7036,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -7334,7 +7399,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -8341,7 +8407,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -8702,7 +8770,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -9063,7 +9133,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -9424,7 +9496,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -9785,7 +9858,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -10146,7 +10221,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -10861,7 +10938,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -11221,7 +11300,7 @@
     "branch": "Centurion",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -11582,7 +11661,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -11943,7 +12024,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -12304,7 +12387,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -12665,7 +12750,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -13741,7 +13828,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -14462,7 +14550,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -14823,7 +14913,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -15184,7 +15276,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -15545,7 +15639,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -16266,7 +16362,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -16627,7 +16725,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -16987,7 +17087,7 @@
     "branch": "Therapist",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -17348,7 +17448,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -17709,7 +17810,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -18070,7 +18173,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -18431,7 +18536,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -19152,7 +19259,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -19799,7 +19908,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -20160,7 +20270,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -20521,7 +20633,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -20882,7 +20996,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -21603,7 +21718,10 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -21964,7 +22082,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard"
     ],
     "skillData": [
       {
@@ -22611,7 +22730,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -23704,7 +23824,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -24069,7 +24190,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Free",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -24434,7 +24557,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -25527,7 +25651,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -26620,7 +26745,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -29533,7 +29659,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -32446,7 +32573,8 @@
     "branch": "Fighter",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Free",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -32811,7 +32939,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -33905,7 +34034,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -35726,7 +35856,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -36091,7 +36222,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -36821,7 +36953,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -40026,7 +40159,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -40391,7 +40525,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -40756,7 +40891,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -41121,7 +41257,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -42214,7 +42351,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -42579,7 +42717,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -43308,7 +43447,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -43673,7 +43813,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -45923,7 +46064,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -46652,7 +46794,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -47017,7 +47160,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -52622,7 +52766,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -53715,7 +53860,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -54080,7 +54226,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -55537,7 +55684,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -59031,7 +59179,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -59396,7 +59545,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -60490,7 +60640,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -60855,7 +61006,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -61220,7 +61372,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -62314,7 +62467,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -63043,7 +63197,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -63771,7 +63926,8 @@
     "branch": "Juggernaut",
     "isCnOnly": false,
     "pools": [
-      "Standard"
+      "Free",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -64136,7 +64292,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -67483,7 +67640,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -68212,7 +68370,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -68577,7 +68736,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -71417,7 +71577,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -72510,7 +72671,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -72875,7 +73037,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -73604,7 +73767,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -73969,7 +74133,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -76883,7 +77048,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -79063,7 +79229,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -79793,7 +79960,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -83360,7 +83528,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -84930,7 +85099,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -87913,7 +88083,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -91006,7 +91177,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -91516,7 +91688,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -95446,7 +95619,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -95956,7 +96130,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -96903,7 +97078,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -104694,7 +104870,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -105204,7 +105381,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -108912,7 +109090,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -111862,7 +112041,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -112372,7 +112552,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -116704,7 +116885,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -117214,7 +117396,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -120018,7 +120201,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -120528,7 +120712,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -121038,7 +121223,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -122493,7 +122679,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -123512,7 +123699,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -125806,7 +125994,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -126825,7 +127014,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -127262,7 +127452,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -129516,7 +129707,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -130971,7 +131163,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -131917,7 +132110,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -133226,7 +133420,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -137881,7 +138076,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -138011,7 +138208,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -138141,7 +138340,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -138502,7 +138703,9 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Standard",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -138863,7 +139066,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {
@@ -139592,7 +139796,8 @@
     "isCnOnly": false,
     "pools": [
       "Kernel",
-      "Kernel CN"
+      "Kernel CN",
+      "Recruitment"
     ],
     "skillData": [
       {

--- a/src/util/hooks/useFilter.ts
+++ b/src/util/hooks/useFilter.ts
@@ -10,13 +10,47 @@ const checkRarity = (op: OpInfo, value: Set<Value>) => value.has(op.rarity);
 const checkCNOnly = (op: OpInfo, value: Set<Value>) => value.has(op.isCnOnly);
 const checkModuleCNOnly = (op: OpInfo, value: Set<Value>) =>
   op.moduleData && op.moduleData.some((m) => value.has(m.isCnOnly));
-const checkSkillLevel = (op: OpInfo, value: Set<Value>) => value.has(op.skill_level);
-const checkMastery = (op: OpInfo, value: Set<Value>) =>
-  op.masteries &&
-  value.values().some((v) =>
-    (v === 0 && op.masteries.every((m) => m === v))
-    || (v !== 0 && op.masteries.some((m) => m === v))
-  );
+
+const checkSkillLevel = (op: OpInfo, value: Set<Value>) => {
+  for (const v of value) {
+    if (
+      (v === 1 && op.skill_level >= 1 && op.skill_level <= 3) ||
+      (v === 4 && op.skill_level >= 4 && op.skill_level <= 6) ||
+      (v === 7 && op.skill_level === 7)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const checkMastery = (op: OpInfo, value: Set<Value>) => {
+  const masteries = op.masteries;
+  // 0 — All are 0 or none
+  if (value.has(0)) {
+    if (!masteries || masteries.every((m) => m === 0)) {
+      return true;
+    }
+  }
+  // 1 -3  — any at value
+  for (let i = 1; i <= 3; i++) {
+    if (value.has(i) && masteries?.some((m) => m === i)) {
+      return true;
+    }
+  }
+  // 4 — exactly two at 3
+  if (value.has(4)) {
+    const count = masteries?.filter((m) => m === 3).length ?? 0;
+    if (count === 2) return true;
+  }
+  // 5 — exactly 3 at 3
+  if (value.has(5)) {
+    const count = masteries?.filter((m) => m === 3).length ?? 0;
+    if (count === 3) return true;
+  }
+  return false;
+};
+
 const checkModuleLevel = (op: OpInfo, value: Set<Value>) =>
   op.modules &&
   value.values().some((v) =>
@@ -24,8 +58,7 @@ const checkModuleLevel = (op: OpInfo, value: Set<Value>) =>
     || (v !== 0 && Object.values(op.modules).some((m) => m === v))
   );;
 const checkPools = (op: OpInfo, value: Set<Value>) =>
-  op.pools && value.values().every((v) => op.pools.some((p) => p === v));
-
+  op.pools && value.values().some((v) => op.pools.some((p) => p === v));
 
 export type Value = string | boolean | number;
 


### PR DESCRIPTION
Pools: fix to OR-filter
+Recruitment
+fixes to Free/Standard detection.

Masteries:
+m6,m9

Skills into 3 buttons, logic change to
SL: 1+,4+,7

Layout tweaks.

image.mjs: (for next images update)
start syncing ui/subclass image folder as it is with subclass_id.
For future autoupdating of new subclasses and subclass filters.

<img width="1103" height="839" alt="image" src="https://github.com/user-attachments/assets/385ee53d-cc64-4af0-9eb3-6fa958b34039" />
<img width="551" height="915" alt="image" src="https://github.com/user-attachments/assets/5d1d8d38-3da2-49ca-ae5c-7e1d57dc110a" />


