### PR TITLE
Feature/UpdateGoalsFromRoster + OrderedGoalsCalculationMode and optimizations

### DIFF
--- a/src/components/planner/depot/ItemNeeded.tsx
+++ b/src/components/planner/depot/ItemNeeded.tsx
@@ -38,10 +38,10 @@ const ItemNeeded: React.FC<Props> = React.memo((props) => {
     component,
     ...rest
   } = props;
-  const { itemId, quantity } = rest;
+  const { itemId, quantity, upcomingQuantity } = rest;
   const item: Item = items[itemId as keyof typeof items];
   const isCraftable = Boolean(item.ingredients);
-  const isComplete = owned >= quantity;
+  const isComplete = owned >= Math.max(0,quantity - (upcomingQuantity?? 0));
   const [rawValue, setRawValue] = useState<string>("");
 
   const [focused, setFocused] = useState(false);

--- a/src/components/planner/depot/ItemStack.tsx
+++ b/src/components/planner/depot/ItemStack.tsx
@@ -8,16 +8,41 @@ import { formatNumber } from "util/fns/depot/itemUtils";
 export interface ItemStackProps extends ItemBaseProps {
   quantity: number;
   showItemNameTooltip?: boolean;
+  upcomingQuantity?: number;
 }
 
 const ItemStack: React.FC<ItemStackProps> = (props) => {
-  const { quantity: rawQuantity, showItemNameTooltip, ...rest } = props;
+  const { quantity: rawQuantity, showItemNameTooltip, upcomingQuantity: upcomingRawQuantity, ...rest } = props;
   const { itemId } = rest;
   const quantity = formatNumber(rawQuantity);
+  const upcomingQuantity = formatNumber(upcomingRawQuantity ?? 0);
   const { name } = itemsJson[itemId as keyof typeof itemsJson];
   const fontSize = (rest.size ?? 96) / 24 + 10;
   const itemBase = (
     <ItemBase {...rest}>
+      {(upcomingRawQuantity ?? 0) > 0 && (
+        <Tooltip title="Income upto Event">
+          <Typography
+            component="span"
+            sx={{
+              display: "inline-block",
+              py: 0.25,
+              px: 0.5,
+              lineHeight: 1,
+              mr: `${(rest.size ?? 96) / 16}px`,
+              mb: `${(rest.size ?? 96) / 16}px`,
+              alignSelf: "start",
+              justifySelf: "end",
+              backgroundColor: "background.paper",
+              zIndex: 2,
+              fontSize: `${fontSize}px`,
+              position: "relative",
+            }}
+          >
+            {`🎁︎${upcomingQuantity}`}
+          </Typography>
+        </Tooltip>
+      )}
       {rawQuantity > 0 && (
         <Typography
           component="span"

--- a/src/components/planner/events/EventsSelector.tsx
+++ b/src/components/planner/events/EventsSelector.tsx
@@ -8,8 +8,10 @@ import {
     Stack,
     Typography,
     useTheme,
-    useMediaQuery
+    useMediaQuery,
+    IconButton
 } from '@mui/material';
+import ClearIcon from '@mui/icons-material/Clear';
 import ItemBase from "components/planner/depot/ItemBase";
 import { EventsSelectorProps } from "types/events"
 import { getItemBaseStyling, customItemsSort, formatNumber, getFarmCSS } from "util/fns/depot/itemUtils";
@@ -23,6 +25,7 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
         eventsData,
         selectedEvent,
         onChange,
+        onOpen,
     } = props;
 
     let label: string;
@@ -51,7 +54,7 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
         }
     };
 
-    const [isSelectFinished, setIsSelectFinished] = useState(true);
+    const [isSelecClosed, setIsSelectClosed] = useState(true);
 
     const theme = useTheme();
     const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
@@ -60,7 +63,6 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
         .sort(([, a], [, b]) => a.index - b.index), [eventsData]);
 
     const handleChange = (eventIndex: number) => {
-        setIsSelectFinished(true);
         if (eventIndex === -1) {
             onChange?.({ ...createEmptyNamedEvent() });
             return;
@@ -73,10 +75,6 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
         return;
     };
 
-    const handleOnClick = () => {
-        setIsSelectFinished(true);
-    }
-
     return (<FormControl sx={{ flexGrow: 1, width: "100%" }}>
         <InputLabel>{label}</InputLabel>
         <Select
@@ -87,21 +85,34 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
                 : -1}
             onChange={(e) => handleChange(Number(e.target.value))}
             onOpen={() => {
-                setIsSelectFinished(false)
+                setIsSelectClosed(false)
+                onOpen?.();
             }}
+            onClose={() => setIsSelectClosed(true)}
             label={label}
             fullWidth
             sx={{ maxHeight: "3rem", minHeight: "3rem", overflow: "hidden" }}
+            IconComponent={(props) => (
+                <IconButton
+                        size="small"
+                        onClick={(e) => {
+                            e.stopPropagation(); // prevent select open
+                            handleChange(-1); // reset to default
+                        }}
+                    >
+                        <ClearIcon fontSize="small" />
+                    </IconButton>
+            )}
         >
             <MenuItem value={-1} key={-1} className="no-underline">{emptyOption}</MenuItem>
             <Divider component="li" />
             {eventsList
                 .map(([name, event]) => (
-                    <MenuItem value={event.index} key={event.index} className="no-underline" onClick={handleOnClick}>
+                    <MenuItem value={event.index} key={event.index} className="no-underline">
                         <Stack direction="row" justifyContent="flex-end" alignItems="center" width="stretch" flexWrap="wrap">
                             <Typography sx={{ mr: "auto", whiteSpace: "wrap", fontSize: fullScreen ? "small" : "unset" }}>
                                 {`${event.index}: ${name} `}
-                            </Typography> {!isSelectFinished ? (
+                            </Typography> {!isSelecClosed ? (
                                 <Stack direction="row">
                                     {(event.farms ?? []).map((id) => [id, 0] as [string, number])
                                         .concat(Object.entries(event.materials)

--- a/src/components/planner/goals/CompletionIndicator.tsx
+++ b/src/components/planner/goals/CompletionIndicator.tsx
@@ -1,0 +1,69 @@
+import { Box, BoxProps } from "@mui/material";
+import clsx from "clsx";
+
+type Orientation = "vertical" | "horizontal";
+
+interface CompletionIndicatorProps extends BoxProps {
+  completable: boolean;
+  completableByCrafting: boolean;
+  orientation?: Orientation; 
+}
+
+export function CompletionIndicator({
+  completable,
+  completableByCrafting,
+  orientation = "vertical",
+  children,
+  className,
+  ...props
+}: CompletionIndicatorProps) {
+  const status = completable ? "completable" : (completableByCrafting && !completable) ? "craftable" : "none";
+  return (
+    <Box
+      {...props}
+      className={clsx(className, {
+        completable: completable,
+        craftable: completableByCrafting && !completable,
+      })}
+      sx={{
+        position: "relative",
+        ...(orientation === "vertical" && {
+          "&:before": {
+            content: '""',
+            position: "absolute",
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: "2px",
+            height: "100%",
+            backgroundColor:
+              status === "completable"
+                ? "success.main"
+                : status === "craftable"
+                ? "warning.main"
+                : "transparent",
+          },
+        }),
+        ...(orientation === "horizontal" && {
+          "&:after": {
+            content: '""',
+            position: "absolute",
+            left: 0,
+            bottom: 0,
+            height: "2px",
+            width: "70%",
+            backgroundColor:
+              status === "completable"
+                ? "success.main"
+                : status === "craftable"
+                ? "warning.main"
+                : "transparent",
+          },
+        }),
+        ...props.sx,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/src/components/planner/goals/GoalFilterDialog.tsx
+++ b/src/components/planner/goals/GoalFilterDialog.tsx
@@ -20,14 +20,18 @@ import { OperatorGoalCategory } from "types/goal";
 import { GoalFilterHook } from "util/hooks/useGoalFilter";
 import { getItemsByIngredient, isMaterial } from "util/fns/depot/itemUtils";
 import AddIcon from '@mui/icons-material/Add';
+import LowPriorityIcon from '@mui/icons-material/LowPriority';
+import { LocalStorageSettings } from "types/localStorageSettings";
 
 interface Props extends GoalFilterHook {
   open: boolean;
   onClose: () => void;
+  handleCalculateGoalsInOrder: () => void;
+  settings: LocalStorageSettings;
 }
 
 const GoalFilterDialog = memo((props: Props) => {
-  const { open, onClose, filters, setFilters, clearFilters } = props;
+  const { open, onClose, filters, setFilters, clearFilters, handleCalculateGoalsInOrder, settings } = props;
   const theme = useTheme();
   const fullScreen = !useMediaQuery(theme.breakpoints.up("sm"));
 
@@ -130,6 +134,12 @@ const GoalFilterDialog = memo((props: Props) => {
                 >
                   Lack Materials
                 </ToggleButton>
+                <IconButton
+                  color={(settings.plannerSettings?.calculateGoalsInOrder ?? true) ? "primary" : "default"}
+                  onClick={() => handleCalculateGoalsInOrder()}
+                >
+                  <LowPriorityIcon />
+                </IconButton>
               </ToggleButtonGroup>
             </Select>
             <Select title="Categories" nobg>

--- a/src/components/planner/goals/GoalGroup.tsx
+++ b/src/components/planner/goals/GoalGroup.tsx
@@ -24,6 +24,7 @@ import Image from "components/base/Image";
 import React, { memo, useCallback, useState } from "react";
 import GoalData from "types/goalData";
 import imageBase from "util/imageBase";
+import { CompletionIndicator } from "./CompletionIndicator";
 
 interface Props {
   operatorGoals: GoalData[] | undefined;
@@ -37,6 +38,8 @@ interface Props {
   onOpSelect: (opId: string, groupName: string) => void;
   onGroupSelect: (groupName: string) => void;
   getCheckboxState: (groupName: string) => { checkboxText: string, checkboxState: { checked: boolean; indeterminate: boolean; disabled: boolean } };
+  completableOperators: string[];
+  completableByCraftingOperators: string[];
 }
 
 const GoalGroup = memo((props: Props) => {
@@ -52,6 +55,8 @@ const GoalGroup = memo((props: Props) => {
     onOpSelect,
     onGroupSelect,
     getCheckboxState,
+    completableOperators,
+    completableByCraftingOperators,
   } = props;
 
   const [expanded, setExpanded] = useState<boolean>(defaultExpanded);
@@ -206,26 +211,31 @@ const GoalGroup = memo((props: Props) => {
                             e.stopPropagation();
                             onOpSelect(operatorGoal.op_id, groupName);
                           }}
+                        ><CompletionIndicator
+                          completable={completableOperators.includes(operatorGoal.op_id)}
+                          completableByCrafting={completableByCraftingOperators.includes(operatorGoal.op_id)}
+                          orientation="horizontal"
                         >
-                          <Image
-                            src={imgUrl}
-                            width={48}
-                            height={48}
-                            alt=""
-                            sx={{
-                              borderBottomLeftRadius: "50%",
-                              borderTopLeftRadius: 8,
-                              borderBottomRightRadius: 4,
-                              filter: (theme) =>
-                                `drop-shadow(-4px -2px 4px ${alpha(theme.palette.background.paper, 0.5)})
+                            <Image
+                              src={imgUrl}
+                              width={48}
+                              height={48}
+                              alt=""
+                              sx={{
+                                borderBottomLeftRadius: "50%",
+                                borderTopLeftRadius: 8,
+                                borderBottomRightRadius: 4,
+                                filter: (theme) =>
+                                  `drop-shadow(-4px -2px 4px ${alpha(theme.palette.background.paper, 0.5)})
                                  ${isEnabled ? "grayscale(0)" : "grayscale(1) opacity(0.6)"}`,
-                              ml: -1.5,
-                              "&:hover": {
-                                backgroundColor: (theme) => alpha(theme.palette.error.dark, isEnabled ? 0.25 : 1)
-                              },
+                                ml: -1.5,
+                                "&:hover": {
+                                  backgroundColor: (theme) => alpha(theme.palette.error.dark, isEnabled ? 0.25 : 1)
+                                },
 
-                            }}
-                          />
+                              }}
+                            />
+                          </CompletionIndicator>
                         </Box>
                       );
                     })}

--- a/src/components/planner/goals/OperatorGoals.tsx
+++ b/src/components/planner/goals/OperatorGoals.tsx
@@ -19,6 +19,7 @@ import operatorJson from "data/operators";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import { Operator } from "types/operators/operator";
 import imageBase from "util/imageBase";
+import { CompletionIndicator } from "./CompletionIndicator";
 
 interface Props {
   operator: Operator;
@@ -30,6 +31,8 @@ interface Props {
   children?: React.ReactNode;
   onOpSelect: (opId: string, groupName: string) => void;
   onGoalRefresh: (operatorGoal: GoalData) => void;
+  completable: boolean;
+  completableByCrafting: boolean;
 }
 
 export const OperatorGoals = memo((props: Props) => {
@@ -42,6 +45,8 @@ export const OperatorGoals = memo((props: Props) => {
     children,
     onOpSelect,
     onGoalRefresh,
+    completable,
+    completableByCrafting,
   } = props;
 
   const [expanded, setExpanded] = useState<boolean>(false);
@@ -154,7 +159,13 @@ export const OperatorGoals = memo((props: Props) => {
                 onOpSelect(operatorGoal.op_id, operatorGoal.group_name);
               }}
             >
-              <Image src={imgUrl} width={64} height={64} alt="" />
+              <CompletionIndicator
+                completable={completable}
+                completableByCrafting={completableByCrafting}
+                orientation="vertical"
+              >
+                <Image src={imgUrl} width={64} height={64} alt="" />
+              </CompletionIndicator>
             </ButtonBase>
             {expanded ? (
               <RemoveCircleIcon

--- a/src/components/planner/goals/OperatorGoals.tsx
+++ b/src/components/planner/goals/OperatorGoals.tsx
@@ -29,6 +29,7 @@ interface Props {
   completeAllGoalsFromOperator: (opId: string, groupName: string) => void;
   children?: React.ReactNode;
   onOpSelect: (opId: string, groupName: string) => void;
+  onGoalRefresh: (operatorGoal: GoalData) => void;
 }
 
 export const OperatorGoals = memo((props: Props) => {
@@ -40,6 +41,7 @@ export const OperatorGoals = memo((props: Props) => {
     completeAllGoalsFromOperator,
     children,
     onOpSelect,
+    onGoalRefresh,
   } = props;
 
   const [expanded, setExpanded] = useState<boolean>(false);
@@ -92,6 +94,14 @@ export const OperatorGoals = memo((props: Props) => {
       completeAllGoalsFromOperator(operatorGoal.op_id, operatorGoal.group_name);
     },
     [completeAllGoalsFromOperator, handleMoreMenuClose, operatorGoal]
+  );
+
+  const handleRefreshGoalClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      handleMoreMenuClose(e);
+      onGoalRefresh(operatorGoal);
+    },
+    [onGoalRefresh, handleMoreMenuClose, operatorGoal]
   );
 
   return (
@@ -192,6 +202,9 @@ export const OperatorGoals = memo((props: Props) => {
           >
             <MenuItem component="button" onClick={handleEditGoalButtonClick}>
               <Typography>Edit Goal</Typography>
+            </MenuItem>
+            <MenuItem component="button" onClick={handleRefreshGoalClick}>
+              <Typography>Update & Clear</Typography>
             </MenuItem>
             <MenuItem component="button" onClick={handleMoveGoalButtonClick}>
               <Typography>Change Group</Typography>

--- a/src/components/planner/goals/PlannerGoalCard.tsx
+++ b/src/components/planner/goals/PlannerGoalCard.tsx
@@ -8,6 +8,8 @@ import getGoalIngredients from "util/fns/depot/getGoalIngredients";
 import { DeleteForever, Upload } from "@mui/icons-material";
 import clsx from "clsx";
 import operatorJson from "data/operators";
+import { CompletionIndicator } from "./CompletionIndicator";
+import { Ingredient } from "types/item";
 
 const GoalCardButton = styled(Button)({
   borderRadius: "0px",
@@ -21,12 +23,13 @@ interface Props {
   groupName: string;
   onGoalDeleted: (goal: PlannerGoal, groupName: string) => void;
   onGoalCompleted: (goal: PlannerGoal, groupName: string) => void;
+  ingredients: Ingredient[];
   completable?: boolean;
   completableByCrafting?: boolean;
 }
 
 const PlannerGoalCard = memo((props: Props) => {
-  const { goal, groupName, onGoalDeleted, onGoalCompleted, completable = false, completableByCrafting = false } = props;
+  const { goal, groupName, onGoalDeleted, onGoalCompleted, completable = false, completableByCrafting = false, ingredients } = props;
   const theme = useTheme();
   const isXSScreen = !useMediaQuery(theme.breakpoints.up("sm"));
 
@@ -60,138 +63,122 @@ const PlannerGoalCard = memo((props: Props) => {
 
   const goalLabel = `${operatorJson[goal.operatorId].name} ${goalName}`;
 
-  const ingredients = getGoalIngredients(goal);
-
   return (
-    <Box
-      component="li"
-      className={clsx({
-        completable: completable,
-        craftable: completableByCrafting && !completable,
-      })}
-      sx={{
-        borderTop: "solid 1px",
-        "&:last-of-type": {
-          borderBottom: "solid 1px",
-          borderColor: "background.light",
-        },
-        borderLeft: "solid 1px",
-        position: "relative",
-        "&:before": {
-          content: '""',
-          position: "absolute",
-          left: 0,
-          top: 0,
-          bottom: 0,
-          width: "2px",
-          height: "100%",
-        },
-        "&.craftable:before": {
-          backgroundColor: "warning.main",
-        },
-        "&.completable:before": {
-          backgroundColor: "success.main",
-        },
-        borderColor: "background.light",
-        backgroundColor: "background.default",
-        display: "grid",
-        gridTemplateColumns: "1fr auto",
-        borderRadius: "0px",
-      }}
+    <CompletionIndicator
+      completable={completable}
+      completableByCrafting={completableByCrafting}
+      orientation="vertical"
     >
       <Box
+        component="div"//why li if no uls
         sx={{
-          display: "flex",
-          p: 1,
-          alignItems: "center",
-          gap: 2,
+          borderTop: "solid 1px",
+          "&:last-of-type": {
+            borderBottom: "solid 1px",
+            borderColor: "background.light",
+          },
+          borderLeft: "solid 1px",
+          borderColor: "background.light",
+          backgroundColor: "background.default",
+          display: "grid",
+          gridTemplateColumns: "1fr auto",
+          borderRadius: "0px",
         }}
       >
-        <OperatorGoalIconography
-          goal={goal}
-          size={isXSScreen ? 32 : 48}
-          sx={{ display: "flex", alignItems: "center", ml: 0.5 }}
-        />
         <Box
           sx={{
             display: "flex",
-            flexDirection: { xs: "column", sm: "row" },
-            alignItems: { xs: "start", sm: "center" },
-            gap: 1,
-            width: "100%",
+            p: 1,
+            alignItems: "center",
+            gap: 2,
           }}
         >
-          <Box sx={{ width: "100%" }}>{goalName}</Box>
-          <Box sx={{ display: "flex", gap: 1, justifyContent: { xs: "start", sm: "end" } }}>
-            {ingredients.map((ingredient) => (
-              <ItemStack
-                key={ingredient.id}
-                itemId={ingredient.id}
-                quantity={ingredient.quantity}
-                size={isXSScreen ? 32 : 48}
-                showItemNameTooltip={true}
-              />
-            ))}
+          <OperatorGoalIconography
+            goal={goal}
+            size={isXSScreen ? 32 : 48}
+            sx={{ display: "flex", alignItems: "center", ml: 0.5 }}
+          />
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: { xs: "column", sm: "row" },
+              alignItems: { xs: "start", sm: "center" },
+              gap: 1,
+              width: "100%",
+            }}
+          >
+            <Box sx={{ width: "100%" }}>{goalName}</Box>
+            <Box sx={{ display: "flex", gap: 1, justifyContent: { xs: "start", sm: "end" } }}>
+              {ingredients.map((ingredient) => (
+                <ItemStack
+                  key={ingredient.id}
+                  itemId={ingredient.id}
+                  quantity={ingredient.quantity}
+                  size={isXSScreen ? 32 : 48}
+                  showItemNameTooltip={true}
+                />
+              ))}
+            </Box>
           </Box>
         </Box>
-      </Box>
-      {/* Action Button */}
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          borderLeft: "1px solid",
-          borderRight: "1px solid",
-          borderColor: "background.light",
-        }}
-      >
-        <Tooltip
-          arrow
-          describeChild
-          title={
-            completable
-              ? "Complete Goal"
-              : completableByCrafting
-              ? "Craft materials and Complete Goal"
-              : "Not enough craftable materials"
-          }
-          placement="left"
+        {/* Action Button */}
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            borderLeft: "1px solid",
+            borderRight: "1px solid",
+            borderColor: "background.light",
+          }}
         >
-          <span>
+          <Tooltip
+            arrow
+            describeChild
+            title={
+              completable
+                ? "Complete Goal"
+                : completableByCrafting
+                  ? "Craft materials and Complete Goal"
+                  : "Not enough craftable materials"
+            }
+            placement="left"
+          >
+            <span>
+              <GoalCardButton
+                aria-label={`Complete goal: ${goalLabel}`}
+                onClick={() => onGoalCompleted(goal, groupName)}
+                sx={{
+                  color: "text.secondary",
+                  "&:hover": {
+                    backgroundColor: (theme) => alpha(theme.palette.success.dark, 0.25),
+                    color: "success.main",
+                  },
+                }}
+                disabled={!completable && !completableByCrafting}
+              >
+                <Upload fontSize="small" />
+              </GoalCardButton>
+            </span>
+          </Tooltip>
+          <Divider />
+          <Tooltip arrow describeChild title="Delete Goal" placement="left">
             <GoalCardButton
-              aria-label={`Complete goal: ${goalLabel}`}
-              onClick={() => onGoalCompleted(goal, groupName)}
+              aria-label={`Delete goal: ${goalLabel}`}
+              onClick={() => onGoalDeleted(goal, groupName)}
               sx={{
                 color: "text.secondary",
                 "&:hover": {
-                  backgroundColor: (theme) => alpha(theme.palette.success.dark, 0.25),
-                  color: "success.main",
+                  backgroundColor: (theme) => alpha(theme.palette.error.dark, 0.25),
+                  color: "error.main",
                 },
               }}
-              disabled={!completable && !completableByCrafting}
             >
-              <Upload fontSize="small" />
+              <DeleteForever fontSize="small" />
             </GoalCardButton>
-          </span>
-        </Tooltip>
-        <Divider />
-        <Tooltip arrow describeChild title="Delete Goal" placement="left">
-          <GoalCardButton
-            aria-label={`Delete goal: ${goalLabel}`}
-            onClick={() => onGoalDeleted(goal, groupName)}
-            sx={{
-              color: "text.secondary",
-              "&:hover": {
-                backgroundColor: (theme) => alpha(theme.palette.error.dark, 0.25),
-                color: "error.main",
-              },
-            }}
-          >
-            <DeleteForever fontSize="small" />
-          </GoalCardButton>
-        </Tooltip>
+          </Tooltip>
+        </Box>
       </Box>
-    </Box>
+    </CompletionIndicator>
   );
 });
 PlannerGoalCard.displayName = "PlannerGoalCard";

--- a/src/components/planner/goals/PlannerGoals.tsx
+++ b/src/components/planner/goals/PlannerGoals.tsx
@@ -531,7 +531,7 @@ const PlannerGoals = (props: Props) => {
 
       for (const goalData of OperatorGroupGoals) {
         let _goal = goalData;
-        const plannerGoals = getPlannerGoals(goalData);
+        const plannerGoals = getPlannerGoals(goalData, undefined, true);
         plannerGoals.forEach((_plannerGoal) => {
           const { updatedGoal, updatedOperator, updatedDepot } = completePlannerGoal(
             _goal,
@@ -798,6 +798,7 @@ const PlannerGoals = (props: Props) => {
               <MenuItem
                 onClick={() => {
                   setReorderOpen(true);
+
                   setAnchorEl(null);
                 }}
               >

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -44,6 +44,7 @@ export interface EventsSelectorProps {
     eventsData: EventsData;
     selectedEvent?: Event | null;
     onChange?: (namedEvent: NamedEvent) => void;
+    onOpen?: () => void;
 }
 
 export type SubmitSource = EventsSelectorProps['dataType'] | 'current' | 'currentWeb'
@@ -52,4 +53,10 @@ export interface TrackerDefaults {
     lastUpdated?: string;
     webEventsData?: WebEventsData;
     eventsData?: EventsData;
+}
+
+export type UpcomingMaterialsData = {
+    materials: Record<string, number>;
+    farmTimes: Record<string, number>;
+    infiniteTimes: Record<string, number>;
 }

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -80,3 +80,9 @@ export type PlannerGoal =
   | PlannerModuleGoal
   | PlannerSkillLevelGoal
   | PlannerLevelGoal;
+  
+export type PlannerGoalCalculated = PlannerGoal & {
+  completable: boolean;
+  completableByCrafting: boolean;
+  ingredients: Ingredient[];
+};

--- a/src/types/goalData.ts
+++ b/src/types/goalData.ts
@@ -1,6 +1,6 @@
 import { Database } from "./supabase";
-import { OperatorData } from "./operators/operator";
-import { OperatorGoalCategory, PlannerGoal } from "./goal";
+import { Operator, OperatorData } from "./operators/operator";
+import { OperatorGoalCategory, PlannerGoal, PlannerGoalCalculated } from "./goal";
 import operatorJson from "../data/operators";
 import { MAX_LEVEL_BY_RARITY } from "../util/changeOperator";
 import getNumSkills from "util/fns/getNumSkills";
@@ -15,6 +15,23 @@ export type GoalDataInsert = Omit<GoalsTable["Insert"], "user_id" | "modules_fro
   modules_from?: Record<string, number> | null;
   modules_to?: Record<string, number> | null;
 };
+
+export type GoalsFilteredCalculatedMap = {
+    groupName: string;
+    index: number;
+    operatorGoals: {
+        operatorGoal: GoalData;
+        plannerGoals: PlannerGoalCalculated[];
+        substantial: boolean;
+        operator: Operator;
+        completable: boolean;
+        completableByCrafting: boolean;
+    }[];
+    inactiveOps: string[];
+    hasSubstantialGoals: boolean;
+    completableOperators: string[];
+    completableByCraftingOperators: string[];
+}[]
 
 const isNumber = (value: any) => typeof value === "number";
 

--- a/src/types/localStorageSettings.ts
+++ b/src/types/localStorageSettings.ts
@@ -14,12 +14,14 @@ export interface PlannerSettings {
   allowAllGoals: boolean;
   sortEmptyGroupsToBottom: boolean;
   inactiveOpsInGroups: InactiveOpsInGroups;
+  autoRefreshGoals: boolean;
 }
 
 const plannerSettings: PlannerSettings = {
   allowAllGoals: false,
   sortEmptyGroupsToBottom: false,
   inactiveOpsInGroups: {},
+  autoRefreshGoals: true,
 };
 
 export interface DepotSettings {
@@ -37,6 +39,7 @@ export interface ImportSettings {
   importOperators: boolean;
   importDepot: boolean;
   importServer: "en" | "kr" | "jp";
+  refreshGoals: boolean;
 }
 
 const depotSettings: DepotSettings = {
@@ -64,6 +67,7 @@ const importSettings: ImportSettings = {
   importOperators: true,
   importDepot: true,
   importServer: "en",
+  refreshGoals: true,
 };
 
 export const defaultSettings: LocalStorageSettings = {

--- a/src/types/localStorageSettings.ts
+++ b/src/types/localStorageSettings.ts
@@ -15,6 +15,7 @@ export interface PlannerSettings {
   sortEmptyGroupsToBottom: boolean;
   inactiveOpsInGroups: InactiveOpsInGroups;
   autoRefreshGoals: boolean;
+  calculateGoalsInOrder: boolean;
 }
 
 const plannerSettings: PlannerSettings = {
@@ -22,6 +23,7 @@ const plannerSettings: PlannerSettings = {
   sortEmptyGroupsToBottom: false,
   inactiveOpsInGroups: {},
   autoRefreshGoals: true,
+  calculateGoalsInOrder: true,
 };
 
 export interface DepotSettings {

--- a/src/util/changeGoal.ts
+++ b/src/util/changeGoal.ts
@@ -1,0 +1,129 @@
+import GoalData from "types/goalData";
+import { Operator } from "types/operators/operator";
+
+export default function changeGoal(goal: GoalData, op: Operator): GoalData {
+    if (goal.op_id !== op.op_id) return goal; // no relation
+
+    const _goal: GoalData = { ...goal };
+
+    changeGoalSKillLevel(_goal, op);
+    //always before elite
+    changeGoalLevel(_goal, op);
+    //always after level
+    changeGoalElite(_goal, op);
+
+    // ---- masteries ----
+    changeGoalMasteries(_goal, op);
+
+    // ---- modules ----
+    changeGoalModules(_goal, op);
+
+    return _goal;
+};
+
+const changeGoalSKillLevel = (goal: GoalData, op: Operator): void => {
+    if (goal.skill_level_from == null || goal.skill_level_to == null) return;
+
+    goal.skill_level_from = Math.max(op.skill_level, goal.skill_level_from) as number;
+    goal.skill_level_to = Math.max(op.skill_level, goal.skill_level_to) as number;
+
+    if (goal.skill_level_from == goal.skill_level_to) {
+        goal.skill_level_from = null;
+        goal.skill_level_to = null;
+    }
+};
+
+const changeGoalLevel = (goal: GoalData, op: Operator): void => {
+    if (goal.level_from == null || goal.level_to == null
+        || goal.elite_from == null || goal.elite_to == null)
+        return;
+    //from
+    if (goal.elite_from < op.elite) {
+        //next elite reached, to current
+        goal.level_from = op.level;
+    } else if (goal.elite_from == op.elite) {
+        //elite stayed the same - pick between
+        goal.level_from = Math.max(op.level, goal.level_from);
+    }
+    //else - goal isn't reachable - leave level_from as is
+
+    //to
+    if (goal.elite_to < op.elite) {
+        //elite over-reached - remove level goals
+        goal.level_from = null;
+        goal.level_to = null;
+    } else if (goal.elite_to == op.elite) {
+        //elite same as goal - pick between op and goal
+        goal.level_to = Math.max(op.level, goal.level_to);
+
+        //if goal level and elite are reached - remove level goals
+        if (goal.level_from == goal.level_to) {
+            goal.level_from = null;
+            goal.level_to = null;
+        }
+    }
+    //else elite not yet reached - leave level_to as is    
+}
+
+const changeGoalElite = (goal: GoalData, op: Operator): void => {
+    goal.elite_from = Math.max(op.elite, goal.elite_from ?? 0);
+    goal.elite_to = Math.max(op.elite, goal.elite_to ?? 0);
+
+    //remove reached elites only if no level-goals
+    if (goal.elite_from == goal.elite_to
+        && goal.level_from == null && goal.level_to == null) {
+        goal.elite_from = null;
+        goal.elite_to = null;
+    }
+};
+
+const changeGoalMasteries = (goal: GoalData, op: Operator): void => {
+    if (goal.masteries_from == null || goal.masteries_to == null) return
+    const from = [...goal.masteries_from];
+    const to = [...goal.masteries_to];
+
+    let removeGoal = true;
+
+    for (let i = 0; i < from.length; i++) {
+        from[i] = Math.max(op.masteries[i], from[i]);
+        to[i] = Math.max(op.masteries[i], to[i]);
+        if (from[i] < to[i]) {
+            removeGoal = false;
+        }
+    }
+
+    if (removeGoal) {
+        goal.masteries_from = null;
+        goal.masteries_to = null;
+    } else {
+        goal.masteries_from = from;
+        goal.masteries_to = to;
+    }
+};
+
+const changeGoalModules = (goal: GoalData, op: Operator): void => {
+    if (!goal.modules_from || !goal.modules_to) return;
+    const from = { ...goal.modules_from };
+    const to = { ...goal.modules_to };
+
+    let removeGoal = true;
+
+    for (const key of Object.keys(goal.modules_from)) {
+        const opVal = op.modules[key] ?? 0;
+
+        from[key] = Math.max(opVal, from[key]);
+        to[key] = Math.max(opVal, to[key]);
+
+        if (from[key] < to[key]) {
+            removeGoal = false;
+        }
+    }
+
+    if (removeGoal) {
+        goal.modules_from = null;
+        goal.modules_to = null;
+    } else {
+        goal.modules_from = from;
+        goal.modules_to = to;
+    }
+};

--- a/src/util/fns/depot/canCompleteByCrafting.ts
+++ b/src/util/fns/depot/canCompleteByCrafting.ts
@@ -18,7 +18,7 @@ const canCompleteByCrafting = (
   const plannedChipCrafts: string[] = [];
 
   // 1. Save original recipe
-  const _materialsNeeded = { ...materialsNeeded };
+  const _materialsNeeded = structuredClone(materialsNeeded);
 
   // 2. populate number of ingredients required for items being crafted
   const ingredientToCraftedItemsMapping: Record<string, string[]> = {};

--- a/src/util/fns/getAvatar.ts
+++ b/src/util/fns/getAvatar.ts
@@ -2,7 +2,7 @@ import { OpInfo } from "types/operators/operator";
 import imageBase from "util/imageBase";
 
 export default function getAvatar(op: OpInfo) {
-  if (op.skin) return `${imageBase}/avatars/${op.skin.replace("#", "%23").replace("+","%2b")}.webp`;
+  if (op.skin && op.skin !== op.id) return `${imageBase}/avatars/${op.skin.replace("#", "%23").replace("+", "%2b")}.webp`;
 
   let intermediate = op.op_id;
   if (op?.elite === 2) {

--- a/src/util/fns/planner/applyGoalsFromOperator.ts
+++ b/src/util/fns/planner/applyGoalsFromOperator.ts
@@ -13,7 +13,7 @@ import {
 
 const isNumber = (value: any) => typeof value === "number";
 export default function applyGoalsFromOperator(goal: Partial<GoalDataInsert>, op: Operator): Operator {
-  let _op = { ...op };
+  let _op = structuredClone(op);
   const opData = operatorJson[op.op_id];
   let changed = false;
 

--- a/src/util/fns/planner/applyGoalsToOperator.ts
+++ b/src/util/fns/planner/applyGoalsToOperator.ts
@@ -13,7 +13,7 @@ import {
 
 const isNumber = (value: any) => typeof value === "number";
 export default function applyGoalsToOperator(goal: Partial<GoalDataInsert>, op: Operator): Operator {
-  let _op = { ...op };
+  let _op = structuredClone(op);
   const opData = operatorJson[op.op_id];
   let changed = false;
 

--- a/src/util/fns/planner/calculateCompletableStatus.ts
+++ b/src/util/fns/planner/calculateCompletableStatus.ts
@@ -1,37 +1,64 @@
 import DepotItem from "types/depotItem";
-import { PlannerGoal } from "types/goal";
+import { OperatorGoalCategory, PlannerGoal } from "types/goal";
 import { LocalStorageSettings } from "types/localStorageSettings";
 import getGoalIngredients from "util/fns/depot/getGoalIngredients";
 import canCompleteByCrafting from "../depot/canCompleteByCrafting";
-import depotToExp from "../depot/depotToExp";
+import operatorJson from "data/operators";
+import { levelingCost } from "pages/tools/level";
+import expToBattleRecords from "../depot/expToBattleRecords";
+import { Ingredient } from "types/item";
 
 const calculateCompletableStatus = (plannerGoal: PlannerGoal, depot: Record<string, DepotItem>, settings: LocalStorageSettings) => {
     if (settings.plannerSettings.allowAllGoals) {
-        return { completable: true, completableByCrafting: false };
+        return { completable: true, completableByCrafting: false, depot, ingredients: getGoalIngredients(plannerGoal) };
+    }
+    let depotUpdate: Record<string,DepotItem>;
+    let completable = false;
+    let completableByCrafting = false;
+    let ingredients: Ingredient[];
+    if (plannerGoal.category === OperatorGoalCategory.Level) {
+        const { exp, lmd } = levelingCost(
+            operatorJson[plannerGoal.operatorId].rarity,
+            plannerGoal.eliteLevel,
+            plannerGoal.fromLevel,
+            plannerGoal.eliteLevel,
+            plannerGoal.toLevel
+        );
+        ingredients = [{id:"4001",quantity:lmd},{id:"EXP",quantity:exp}];
+        const { success, depot: _depot } = expToBattleRecords(exp, depot);
+        _depot["4001"].stock = Math.max(0, _depot["4001"].stock - lmd);
+
+        completableByCrafting = false;
+        completable = success
+            && (depot["4001"].stock >= lmd || settings.depotSettings.ignoreLmdInCrafting);        
+        
+        depotUpdate = completable ? _depot : depot;
+    } else {
+        ingredients = getGoalIngredients(plannerGoal);
+        const { craftableItems, depot: _depot } = canCompleteByCrafting(
+            Object.fromEntries(ingredients.map(({ quantity, id }) => [id, quantity])),
+            depot,
+            settings.depotSettings.crafting,
+            settings.depotSettings.ignoreLmdInCrafting
+        );
+
+        completableByCrafting = ingredients.every(
+            ({ id, quantity }) =>
+                (settings.depotSettings.ignoreLmdInCrafting && id === "4001") ||
+                (/* id === "EXP" ? depotToExp(depot) :  */depot?.[id]?.stock) >= quantity ||
+                craftableItems[id]
+        );
+
+        completable = ingredients.every(
+            ({ id, quantity }) =>
+                (settings.depotSettings.ignoreLmdInCrafting && id === "4001") ||
+                (/* id === "EXP" ? depotToExp(depot) : */ depot?.[id]?.stock) >= quantity
+        );
+
+        depotUpdate = (completable || completableByCrafting) ? _depot : depot;
     }
 
-    const ingredients = getGoalIngredients(plannerGoal);
-    const { craftableItems } = canCompleteByCrafting(
-        Object.fromEntries(ingredients.map(({ quantity, id }) => [id, quantity])),
-        depot,
-        settings.depotSettings.crafting,
-        settings.depotSettings.ignoreLmdInCrafting
-    );
-
-    const completableByCrafting = ingredients.every(
-        ({ id, quantity }) =>
-            (settings.depotSettings.ignoreLmdInCrafting && id === "4001") ||
-            (id === "EXP" ? depotToExp(depot) : depot[id]?.stock) >= quantity ||
-            craftableItems[id]
-    );
-
-    const completable = ingredients.every(
-        ({ id, quantity }) =>
-            (settings.depotSettings.ignoreLmdInCrafting && id === "4001") ||
-            (id === "EXP" ? depotToExp(depot) : depot[id]?.stock) >= quantity
-    );
-
-    return { completable, completableByCrafting };
+    return { completable, completableByCrafting, depot: depotUpdate, ingredients };
 };
 
 export default calculateCompletableStatus;

--- a/src/util/hooks/useEvents.ts
+++ b/src/util/hooks/useEvents.ts
@@ -4,13 +4,14 @@ import { EventsData, SubmitEventProps, WebEventsData } from 'types/events'
 import { createDefaultEventsData, createEmptyEvent, reindexEvents, getNextMonthsData } from "util/fns/eventUtils"
 import useLocalStorage from "./useLocalStorage";
 
-function useEvents(): {
-    eventsData: EventsData,
-    setEvents: (newEventsData: EventsData) => void,
-    submitEvent: (submit: SubmitEventProps) => null | [string, number][],
-    getNextMonthsData: (months?: number) => EventsData,
-    createDefaultEventsData: (webEvents: WebEventsData) => EventsData,
-} {
+export interface EventsHook {
+    readonly eventsData: EventsData;
+    readonly setEvents: (newEventsData: EventsData) => void;
+    readonly submitEvent: (submit: SubmitEventProps) => null | [string, number][];
+    readonly getNextMonthsData: (months?: number) => EventsData;
+    readonly createDefaultEventsData: (webEvents: WebEventsData) => EventsData;
+}
+export default function useEvents(): EventsHook {
     const [eventsData, _setEvents] = useLocalStorage<EventsData>("trackerEvents", {});
     const [settings, setSettings] = useSettings();
 
@@ -146,6 +147,5 @@ function useEvents(): {
     return {
         eventsData: _eventsData, setEvents, submitEvent, getNextMonthsData,
         createDefaultEventsData: clientCreateDefaultEventsData
-    }
+    } as const;
 }
-export default useEvents;

--- a/src/util/hooks/useEventsDefaults.ts
+++ b/src/util/hooks/useEventsDefaults.ts
@@ -2,7 +2,14 @@ import { useState } from 'react';
 import useLocalStorage from './useLocalStorage';
 import { TrackerDefaults } from 'types/events';
 
-export function useEventsDefaults() {
+export interface EventsDefaultsHook {
+  readonly trackerDefaults: TrackerDefaults;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly fetchDefaults: () => Promise<void>;
+}
+
+export default function useEventsDefaults(): EventsDefaultsHook {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -62,5 +69,5 @@ export function useEventsDefaults() {
 }, []
 ); */
 
-  return { trackerDefaults, loading, error, fetchDefaults: fetchData };
+  return { trackerDefaults, loading, error, fetchDefaults: fetchData } as const;
 }

--- a/src/util/hooks/useGoalGroups.ts
+++ b/src/util/hooks/useGoalGroups.ts
@@ -4,6 +4,17 @@ import { GroupsDataInsert } from "types/groupData";
 import handlePostgrestError from "util/fns/handlePostgrestError";
 import useLocalStorage from "./useLocalStorage";
 
+export interface GoalGroupsHook {
+    readonly groups: string[];
+    readonly putGroups: (goalGroupInsert: {
+        group_name: string;
+        sort_order?: number | undefined;
+        user_id?: string | undefined;
+    }[]) => Promise<void>;
+    readonly renameGroup: (oldName: string, newName: string) => Promise<void>;
+    readonly removeGroup: (groupName: string) => Promise<void>;
+}
+
 function useGoalGroups() {
   const [groups, _setGroups] = useLocalStorage<string[]>("v3_groups", []);
   const [user_id, setUserId] = useState<string>("");

--- a/src/util/hooks/useGoals.ts
+++ b/src/util/hooks/useGoals.ts
@@ -9,6 +9,15 @@ import { combineGoals } from "util/fns/planner/combineGoals";
 import { enqueueSnackbar } from "notistack";
 import _ from "lodash";
 
+export interface GoalsHook {
+    readonly goals: GoalData[];
+    readonly updateGoals: (goalsData: GoalDataInsert[]) => Promise<void>;
+    readonly removeAllGoals: () => Promise<void>;
+    readonly removeAllGoalsFromGroup: (groupName: string, cleanLocal?: boolean) => Promise<void>;
+    readonly removeAllGoalsFromOperator: (opId: string, groupName: string) => Promise<void>;
+    readonly changeLocalGoalGroup: (oldGoalGroup: string, newGoalGroup: string) => Promise<void>;
+}
+
 const fillNull = (goal: GoalDataInsert, index: number): GoalDataInsert => {
   const {
     op_id,


### PR DESCRIPTION
Functions to update /clean goals based current roster.

Optional, enabled by default in import and planner.
-Update all goals with account sync
-Update on planner page load once with useEffect[], after ops/goals load from db.  
-Menu setttings option to disable update on planer load.
-menu items to update all goals and one goal
+
-added Email bind text right above email in GameImport
-fixed some goalAdd-Edit bugs in commits
-fixed CompleteAllGoals not doing level goals in correct order with elite.

added BIG commit:
[Refactor goal calculation & filtering; add ordered scenario](https://github.com/neeia/ak-roster/pull/82/commits/5a92856b67e381ecb27be78f3045092807669486)
- +ordered goal calculation logic and toggle (for PlannerGoals & Summary)
- +complete/craftable Indicator for Op & Group levels (PlannerGoals & children)
- refactor goal filters to include ordered scenario (useGoalFilter, GoalFilterDialog)
    - Split useGoalFilter().filterFunction into two:
        - .byOperatorsAndGroups → pre-removes disabled items from calculations
        - .byGoalsAndMaterials → partly remember completability for Op & group levels.
- Moved hooks up to planner.tsx: unified & memoized calcs: groupedGoals & completable & ingredients
- Moved up to planner.tsx & memoized: selectedEvent & upcomingMaterials => MaterialsNeeded & groupedGoals
    - Changes in MaterialNeeded & children for upcomingMats
- EventsSelector in second row at top of Depot

<img width="877" height="619" alt="image" src="https://github.com/user-attachments/assets/76b202db-850c-4234-8674-bba26f233a99" />
<img width="630" height="483" alt="image" src="https://github.com/user-attachments/assets/8cd0d0f2-ec4d-48d8-9e70-0c5afa3688dd" />
<img width="499" height="490" alt="image" src="https://github.com/user-attachments/assets/f0b5e9c3-5e63-40d2-b4be-3a82eae63f92" />
<img width="282" height="313" alt="image" src="https://github.com/user-attachments/assets/9c3c2ecd-23b4-4d4e-9ccc-a0aa08f5d0ed" />

Goal calculations part:
<img width="1098" height="576" alt="image" src="https://github.com/user-attachments/assets/1f545e0b-e8a9-4f0f-bf9b-4be33c0f755f" />
<img width="510" height="728" alt="image" src="https://github.com/user-attachments/assets/d6ae86c4-ac70-4b75-9c42-e10e9cc4c69d" />
<img width="910" height="452" alt="image" src="https://github.com/user-attachments/assets/3ec07a4e-06d8-4d60-8351-40ad3f0fd971" />
<img width="921" height="605" alt="image" src="https://github.com/user-attachments/assets/30daa627-735c-43eb-b4b7-defe2c18c9b9" />
<img width="906" height="589" alt="image" src="https://github.com/user-attachments/assets/3e6593f1-a73d-4e37-8d94-6333faf4640e" />
<img width="1070" height="728" alt="image" src="https://github.com/user-attachments/assets/cf009edc-77c7-479a-98e8-1fa95dce10a3" />


