### PR TITLE
FixesAndAddons/SummaryAndGoals

### DIFF
--- a/scripts/skins.mjs
+++ b/scripts/skins.mjs
@@ -18,8 +18,12 @@ const createSkinsJson = () => {
   [...Object.values(cnSkinTable.charSkins)].forEach((skin) => {
     if (!isOperator(skin.charId)) return;
     const enSkin = enSkinTable.charSkins[skin.skinId];
-    skinObj[skin.charId] ??= [];
-    skinObj[skin.charId].push({
+    let charId = skin.charId;
+    if (charId === "char_002_amiya") {
+      charId = skin.skinId.split(/[@#]/)[0];
+    }
+    skinObj[charId] ??= [];
+    skinObj[charId].push({
       skinId: skin.skinId,
       skinName: (enSkin && enSkin.displaySkin.skinName) ?? skin.displaySkin.skinName ?? null,
       avatarId: skin.avatarId,

--- a/src/components/data/SupportBlock.tsx
+++ b/src/components/data/SupportBlock.tsx
@@ -33,10 +33,11 @@ function getModUrl(mod: ModuleData) {
 
 interface Props extends BoxProps {
   op: OpInfo;
+  forceEliteAvatar?: boolean;
 }
 
 const SupportBlock = (props: Props) => {
-  const { op, sx, ...rest } = props;
+  const { op, sx, forceEliteAvatar = false, ...rest } = props;
 
   const reg = /( the )|\(/gi;
   const splitName = op.name.replace(/\)$/, "").split(reg);
@@ -99,7 +100,7 @@ const SupportBlock = (props: Props) => {
         </Box>
         {/* Avatar */}
         <Image
-          src={getAvatar(op)}
+          src={getAvatar(op, forceEliteAvatar)}
           alt=""
           sx={{
             height: 80,

--- a/src/components/planner/ItemInfoPopover/ItemSources.tsx
+++ b/src/components/planner/ItemInfoPopover/ItemSources.tsx
@@ -16,10 +16,12 @@ interface Props {
 const ItemSources: React.FC<Props> = (props) => {
   const { item, openEventTracker, eventsData } = props;
 
-  const eventNames = Object.keys(eventsData ?? {});
+  const eventNames = Object.keys(eventsData ?? {}).filter(
+    (name) => !eventsData![name].disabled
+  );
 
   let total = 0, farmableTimes = 0;
-  let firstInfiniteShop = {index: Number.MAX_SAFE_INTEGER, name: ""};
+  let firstInfiniteShop = { index: Number.MAX_SAFE_INTEGER, name: "" };
 
   const materialData = eventNames.flatMap((eventName) => {
     const event = eventsData[eventName];
@@ -29,7 +31,7 @@ const ItemSources: React.FC<Props> = (props) => {
       results.push({ index: event.index, event: eventName, amount: "farmable" });
     }
     if (event.infinite?.includes(item.id) && event.index < firstInfiniteShop.index) {
-      firstInfiniteShop = {index: event.index, name: eventName};
+      firstInfiniteShop = { index: event.index, name: eventName };
     }
     if (item.id in event.materials) {
       const amount = event.materials[item.id];
@@ -61,33 +63,33 @@ const ItemSources: React.FC<Props> = (props) => {
           Add or import events in the Event Tracker to see upcoming sources
         </Button>
       ) : Object.keys(materialData).length === 0 && !firstInfiniteShop.name ? (
-          <Box sx={{ paddingLeft: "4px" }}>{"No upcoming events have this material :("}</Box>
-        ) : (
-          <>
-            <Box
-              component="dl"
-              sx={{
-                display: "grid",
-                gridTemplateColumns: "1fr auto",
-                rowGap: "2px",
-                columnGap: "16px",
-                maxHeight: "max(30vh, 300px)",
-                overflowY: "auto"
-              }}
-            >
-              {materialData.map((result) =>
-                <EventRow key={result.event + "|" + result.amount} sx={{ maxWidth: "300px" }} label={result.event} amount={result.amount} />
-              )}
-            </Box>
-            <Box component="dl" sx={{ display: "grid", gridTemplateColumns: "1fr auto" }}>
-              <EventRow label="Total" amount={formatNumber(total) + (farmableTimes ? (" + " + farmableTimes + " farmable") : "")} 
-                sx={{ borderTop: "1px solid", borderColor: "text.secondary" }} />
-            </Box>
-            {firstInfiniteShop.name &&
-              <Typography sx={{ paddingX: "4px", maxWidth: "600px" }}>Infinite stock in event shops, next available: {firstInfiniteShop.name}</Typography>
-            }
-          </>
-        )
+        <Box sx={{ paddingLeft: "4px" }}>{"No upcoming events have this material :("}</Box>
+      ) : (
+        <>
+          <Box
+            component="dl"
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "1fr auto",
+              rowGap: "2px",
+              columnGap: "16px",
+              maxHeight: "max(30vh, 300px)",
+              overflowY: "auto"
+            }}
+          >
+            {materialData.map((result) =>
+              <EventRow key={result.event + "|" + result.amount} sx={{ maxWidth: "300px" }} label={result.event} amount={result.amount} />
+            )}
+          </Box>
+          <Box component="dl" sx={{ display: "grid", gridTemplateColumns: "1fr auto" }}>
+            <EventRow label="Total" amount={formatNumber(total) + (farmableTimes ? (" + " + farmableTimes + " farmable") : "")}
+              sx={{ borderTop: "1px solid", borderColor: "text.secondary" }} />
+          </Box>
+          {firstInfiniteShop.name &&
+            <Typography sx={{ paddingX: "4px", maxWidth: "600px" }}>Infinite stock in event shops, next available: {firstInfiniteShop.name}</Typography>
+          }
+        </>
+      )
       }
     </ItemInfoSection>
   );

--- a/src/components/planner/depot/MaterialsNeeded.tsx
+++ b/src/components/planner/depot/MaterialsNeeded.tsx
@@ -47,8 +47,8 @@ interface Props extends EventsHook, EventsDefaultsHook {
 
 const MaterialsNeeded = React.memo((props: Props) => {
   const { goals, goalData, depot, putDepot, resetDepot, settings, setSettings, depotIsUnsaved, refreshDepotDebounce,
-    eventsData, setEvents, submitEvent,
-    loading, trackerDefaults, fetchDefaults,
+    eventsData, setEvents, submitEvent, toggleEvent,
+    loading, trackerDefaults, fetchDefaults, toggleDefaultsEvent,
     selectedEvent, setSelectedEvent,
     upcomingMaterialsData,
     groupedGoalsMap,
@@ -79,9 +79,9 @@ const MaterialsNeeded = React.memo((props: Props) => {
 
   const upcomingEvents = useMemo(() =>
     Object.keys(eventsData ?? {}).length > 0
-      ? { source: eventsData, name: "Tracker" }
-      : { source: trackerDefaults?.eventsData ?? {}, name: "Defaults" }
-    , [eventsData, trackerDefaults.eventsData])
+      ? { source: eventsData, name: "Tracker", toggleFunction: toggleEvent }
+      : { source: trackerDefaults?.eventsData ?? {}, name: "Defaults", toggleFunction: toggleDefaultsEvent }
+    , [eventsData, trackerDefaults.eventsData, toggleEvent, toggleDefaultsEvent])
 
   const handleItemClick = useCallback((itemId: string) => {
     setPopoverItemId(itemId);
@@ -543,6 +543,7 @@ const MaterialsNeeded = React.memo((props: Props) => {
                   fetchDefaults();
                 }
               }}
+              onEventToggle={upcomingEvents.toggleFunction}
             /></Box>
           <Box
             component="ul"

--- a/src/components/planner/events/EventsSelector.tsx
+++ b/src/components/planner/events/EventsSelector.tsx
@@ -16,6 +16,7 @@ import ItemBase from "components/planner/depot/ItemBase";
 import { EventsSelectorProps } from "types/events"
 import { getItemBaseStyling, customItemsSort, formatNumber, getFarmCSS } from "util/fns/depot/itemUtils";
 import { createEmptyEvent, createEmptyNamedEvent } from 'util/fns/eventUtils';
+import BlockIcon from '@mui/icons-material/Block';
 
 export const EventsSelector = React.memo((props: EventsSelectorProps) => {
     const {
@@ -26,6 +27,7 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
         selectedEvent,
         onChange,
         onOpen,
+        onEventToggle,
     } = props;
 
     let label: string;
@@ -94,14 +96,14 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
             sx={{ maxHeight: "3rem", minHeight: "3rem", overflow: "hidden" }}
             IconComponent={(props) => (
                 <IconButton
-                        size="small"
-                        onClick={(e) => {
-                            e.stopPropagation(); // prevent select open
-                            handleChange(-1); // reset to default
-                        }}
-                    >
-                        <ClearIcon fontSize="small" />
-                    </IconButton>
+                    size="small"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        handleChange(-1);
+                    }}
+                >
+                    <ClearIcon fontSize="small" />
+                </IconButton>
             )}
         >
             <MenuItem value={-1} key={-1} className="no-underline">{emptyOption}</MenuItem>
@@ -110,9 +112,20 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
                 .map(([name, event]) => (
                     <MenuItem value={event.index} key={event.index} className="no-underline">
                         <Stack direction="row" justifyContent="flex-end" alignItems="center" width="stretch" flexWrap="wrap">
+                            {!isSelecClosed && onEventToggle && <IconButton
+                                sx={{
+                                    opacity: !event.disabled ? 0.2 : 1,
+                                    color: event.disabled ? "primary.main" : "inherit",
+                                }}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onEventToggle(name)
+                                }}>
+                                <BlockIcon fontSize='small' />
+                            </IconButton>}
                             <Typography sx={{ mr: "auto", whiteSpace: "wrap", fontSize: fullScreen ? "small" : "unset" }}>
                                 {`${event.index}: ${name} `}
-                            </Typography> {!isSelecClosed ? (
+                            </Typography> {!isSelecClosed && (!onEventToggle || !event.disabled) && (
                                 <Stack direction="row">
                                     {(event.farms ?? []).map((id) => [id, 0] as [string, number])
                                         .concat(Object.entries(event.materials)
@@ -125,7 +138,7 @@ export const EventsSelector = React.memo((props: EventsSelectorProps) => {
                                             </ItemBase>
                                         ))}
                                     <small>{"..."}</small>
-                                </Stack>) : null}
+                                </Stack>)}
                         </Stack>
                     </MenuItem>
                 ))}

--- a/src/components/planner/events/EventsTrackerDialog.tsx
+++ b/src/components/planner/events/EventsTrackerDialog.tsx
@@ -53,6 +53,7 @@ import SubmitEventDialog from 'components/planner/events/SubmitEventDialog';
 import { MAX_SAFE_INTEGER, getWidthFromValue, formatNumber, standardItemsSort, getItemBaseStyling, isMaterial, getDefaultEventMaterials, getFarmCSS } from 'util/fns/depot/itemUtils'
 import { createEmptyEvent, createEmptyNamedEvent, getDateString, reindexEvents } from "util/fns/eventUtils"
 import ItemEditBox from 'components/planner/events/ItemEditBox';
+import BlockIcon from '@mui/icons-material/Block';
 
 const Transition = React.forwardRef(function Transition(
     props: TransitionProps & {
@@ -137,6 +138,7 @@ const EventsTrackerDialog = React.memo((props: Props) => {
                 <li>Provided by <Link href="https://ak-events-tracker.vercel.app/" underline="always">ak-events-tracker</Link>.</li>
                 <li>Data from CN prts.wiki events, adjusted by six months, is combined with monthly estimates and auto sorted by date. These are defaults used by the tracker.</li>
                 <li>The default list can be used as-is, or as shifts occur in global shedule, can be used as base to create adjusted personal list</li>
+                <li>Events from Tracker and Defaults can be <BlockIcon sx={{ display: "inline-block", verticalAlign: "middle", color: "primary.main" }} /> disabled in the Events Selector, so they are excluded from calculations.</li>
             </ul>
         </>;
 
@@ -576,14 +578,17 @@ const EventsTrackerDialog = React.memo((props: Props) => {
     };
 
     const handleSetEventsFromDefaults = useCallback(() => {
-        if (trackerDefaults && trackerDefaults.eventsData
-            && Object.keys(trackerDefaults.eventsData).length > 0) {
+        if (trackerDefaults?.eventsData && Object.keys(trackerDefaults.eventsData).length > 0) {
+            const enabledEvents = reindexEvents(
+                Object.fromEntries(
+                    Object.entries(trackerDefaults.eventsData)
+                        .filter(([, eventData]) => !eventData.disabled)
+                ));
 
-            setRawEvents(trackerDefaults.eventsData);
-            onChange(trackerDefaults.eventsData);
+            setRawEvents(enabledEvents);
+            onChange(enabledEvents);
         }
-    }, [trackerDefaults, onChange, setRawEvents]
-    )
+    }, [trackerDefaults, onChange, setRawEvents]);
 
     const getBuilderButton = () => {
         return (<Button

--- a/src/components/planner/goals/PlannerGoalAdd.tsx
+++ b/src/components/planner/goals/PlannerGoalAdd.tsx
@@ -599,8 +599,8 @@ const PlannerGoalAdd = (props: Props) => {
                   <SelectGroup.FromTo
                     sx={{ gridTemplateColumns: "1fr 1fr", "& .potential": { display: "none" }, overflow: "hidden" }}
                   >
-                    <SupportBlock op={{ ...applyGoalsFromOperator(goalBuilder, currentOp), ...opData }} />
-                    <SupportBlock op={{ ...applyGoalsToOperator(goalBuilder, goalOp), ...opData }} />
+                    <SupportBlock op={{ ...applyGoalsFromOperator(goalBuilder, currentOp), ...opData }} forceEliteAvatar={true} />
+                    <SupportBlock op={{ ...applyGoalsToOperator(goalBuilder, goalOp), ...opData }} forceEliteAvatar={true}/>
                   </SelectGroup.FromTo>
                 )}
               </Collapse>

--- a/src/components/planner/goals/PlannerGoals.tsx
+++ b/src/components/planner/goals/PlannerGoals.tsx
@@ -13,6 +13,7 @@ import {
   ListItemText,
   MenuItem,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import Grid from "@mui/material/Grid2";
@@ -811,10 +812,12 @@ const PlannerGoals = (props: Props) => {
           }}
         >
           <Grid>
-            <IconButton size="large" onClick={handleCalculateGoalsInOrder}
-              color={(settings.plannerSettings?.calculateGoalsInOrder ?? true) ? "primary" : "default"}>
-              <LowPriorityIcon fontSize="inherit" />
-            </IconButton>
+            <Tooltip title="Calculate goals in descending order">
+              <IconButton size="large" onClick={handleCalculateGoalsInOrder}
+                color={(settings.plannerSettings?.calculateGoalsInOrder ?? true) ? "primary" : "default"}>
+                <LowPriorityIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
             <IconButton size="large" onClick={() => setFilterOpen(true)}>
               <FilterAltOutlinedIcon fontSize="inherit" />
             </IconButton>

--- a/src/data/patch.ts
+++ b/src/data/patch.ts
@@ -1,5 +1,29 @@
 const patch = [
   {
+    version: "3.3.3",
+    date: "October 03, 2025",
+    title: "Planner Upgrades and QoLs",
+    content: ["Goals sync on import, ordered calculation and more"],
+    changelog: [
+      "Goals",
+      [
+        "Can be auto updated & cleared after account import or from planner page menus",
+        "Ordered calculations mode to process the goal list from first to last, and new operator indicators to help you see where materials will actually run out",
+      ],
+      "Summary & Upcoming Events",
+      [
+      "Summary with ordered calculation mode now shows material crafting grouped in your operators order from goals list",
+      "Crafting materials directly from ordered summary - click on +1. And its safeguarded from wasting materials of previous operator",
+      "Upcoming events are now interated in all planner and its now possible to disable any of them in list on the fly",
+      ],
+      "Also previous updates include",
+      [
+        "More filters for operators: class Branches, Pools, Masteries, Modules and Skill levels",
+        "Various bugfixes and optimizations"
+      ]
+    ],
+  },
+  {
     version: "3.3.2",
     date: "April 28, 2025",
     title: "Importing is Back",

--- a/src/data/skins.json
+++ b/src/data/skins.json
@@ -2839,30 +2839,6 @@
       "skinName": "Seedsower",
       "avatarId": "char_002_amiya_test#1",
       "sortId": 6
-    },
-    {
-      "skinId": "char_1037_amiya3@sale#13",
-      "skinName": "Solo Around The World",
-      "avatarId": "char_1037_amiya3_sale#13",
-      "sortId": 18
-    },
-    {
-      "skinId": "char_1001_amiya2@casc#1",
-      "skinName": "触及星辰",
-      "avatarId": "char_1001_amiya2_casc#1",
-      "sortId": 375
-    },
-    {
-      "skinId": "char_1001_amiya2#2",
-      "skinName": null,
-      "avatarId": "char_1001_amiya2_2",
-      "sortId": -1
-    },
-    {
-      "skinId": "char_1037_amiya3#2",
-      "skinName": null,
-      "avatarId": "char_1037_amiya3_2",
-      "sortId": -1
     }
   ],
   "char_405_absin": [
@@ -7825,6 +7801,34 @@
       "skinName": "The Next Afternoon Tea",
       "avatarId": "char_263_skadi_marthe#5",
       "sortId": 216
+    }
+  ],
+  "char_1037_amiya3": [
+    {
+      "skinId": "char_1037_amiya3@sale#13",
+      "skinName": "Solo Around The World",
+      "avatarId": "char_1037_amiya3_sale#13",
+      "sortId": 18
+    },
+    {
+      "skinId": "char_1037_amiya3#2",
+      "skinName": null,
+      "avatarId": "char_1037_amiya3_2",
+      "sortId": -1
+    }
+  ],
+  "char_1001_amiya2": [
+    {
+      "skinId": "char_1001_amiya2@casc#1",
+      "skinName": "触及星辰",
+      "avatarId": "char_1001_amiya2_casc#1",
+      "sortId": 375
+    },
+    {
+      "skinId": "char_1001_amiya2#2",
+      "skinName": null,
+      "avatarId": "char_1001_amiya2_2",
+      "sortId": -1
     }
   ]
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -12,7 +12,7 @@ export type NamedEvent = Event & {
 };
 
 export type EventsData = {
-    [name: string]: Event;
+    [name: string]: Event & { disabled?: boolean };
 }
 
 export type WebEvent = {
@@ -45,6 +45,7 @@ export interface EventsSelectorProps {
     selectedEvent?: Event | null;
     onChange?: (namedEvent: NamedEvent) => void;
     onOpen?: () => void;
+    onEventToggle?: (name: string) => void;
 }
 
 export type SubmitSource = EventsSelectorProps['dataType'] | 'current' | 'currentWeb'

--- a/src/util/fns/depot/itemUtils.ts
+++ b/src/util/fns/depot/itemUtils.ts
@@ -130,9 +130,9 @@ const summarySortId: [string, number][] = [
     ["Certificate", -1],
     //all mats= 0
     ["Summary", 1],
-    ["Catalyst", 3],
-    ["chip", 2],
-    ["Chip", 2],
+    ["Catalyst", 2],
+    ["chip", 3],
+    ["Chip", 3],
     ["Data", 4],
     ["Record", 5],
 ];

--- a/src/util/fns/eventUtils.ts
+++ b/src/util/fns/eventUtils.ts
@@ -210,7 +210,7 @@ export const getTotalMaterialsUptoSelectedEvent = (
 
     const _eventsData = eventsData;
     const _filteredEvents = Object.entries(_eventsData)
-        .filter(([, eventData]) => eventData.index <= selectedEvent.index);
+        .filter(([, eventData]) => eventData.index <= selectedEvent.index && !eventData.disabled);
     const _eventMaterials = _filteredEvents
         .reduce((acc, [, eventData]) => {
             if (!eventData.materials) return acc;

--- a/src/util/fns/getAvatar.ts
+++ b/src/util/fns/getAvatar.ts
@@ -1,8 +1,8 @@
 import { OpInfo } from "types/operators/operator";
 import imageBase from "util/imageBase";
 
-export default function getAvatar(op: OpInfo) {
-  if (op.skin && op.skin !== op.id) return `${imageBase}/avatars/${op.skin.replace("#", "%23").replace("+", "%2b")}.webp`;
+export default function getAvatar(op: OpInfo, forceElite:boolean=false) {
+  if (op.skin && !forceElite) return `${imageBase}/avatars/${op.skin.replace("#", "%23").replace("+", "%2b")}.webp`;
 
   let intermediate = op.op_id;
   if (op?.elite === 2) {

--- a/src/util/hooks/useEvents.ts
+++ b/src/util/hooks/useEvents.ts
@@ -10,6 +10,7 @@ export interface EventsHook {
     readonly submitEvent: (submit: SubmitEventProps) => null | [string, number][];
     readonly getNextMonthsData: (months?: number) => EventsData;
     readonly createDefaultEventsData: (webEvents: WebEventsData) => EventsData;
+    readonly toggleEvent: (name: string) => void;
 }
 export default function useEvents(): EventsHook {
     const [eventsData, _setEvents] = useLocalStorage<EventsData>("trackerEvents", {});
@@ -70,6 +71,21 @@ export default function useEvents(): EventsHook {
         });
 
         return _items;
+    };
+
+    const toggleEvent = (name: string) => {
+        _setEvents((prev) => {
+            const event = prev[name];
+            if (!event) return prev;
+
+            return {
+                ...prev,
+                [name]: {
+                    ...event,
+                    disabled: !event.disabled
+                },
+            }
+        });
     };
 
     const submitEvent = useCallback((props: SubmitEventProps): null | [string, number][] => {
@@ -146,6 +162,7 @@ export default function useEvents(): EventsHook {
     }
     return {
         eventsData: _eventsData, setEvents, submitEvent, getNextMonthsData,
-        createDefaultEventsData: clientCreateDefaultEventsData
+        createDefaultEventsData: clientCreateDefaultEventsData,
+        toggleEvent
     } as const;
 }


### PR DESCRIPTION
plannerGoals: tooltip for ordered goals button

fix: "Tracker cant update depot":
 - MaterialsNeeded: pass depot functions to children without inner-input 500ms debounce.

 depot sort order: needed>toCraft > all other

getAvatar: reroll fix, e0 skin should be allowed. +optional forceEliteAvatar for GoalAdd Cards indication.