### PR TITLE
ordered mode fixes: wrong order of goals and logic bugs

### DIFF
--- a/src/components/planner/depot/MaterialsSummaryDialog.tsx
+++ b/src/components/planner/depot/MaterialsSummaryDialog.tsx
@@ -152,7 +152,7 @@ const MaterialsSummaryDialog = React.memo((props: Props) => {
                 <li>Combined materials from selected and previous events are factored into all calculations, reducing required amounts.</li>
                 <li>Highlights farmable tier 3 materials from selected event if they were set in the tracker.</li>
                 <li>
-                    Materials from <BlockIcon sx={{ display: "inline-block", verticalAlign: "middle", color:"primary.main" }} /> disabled Events are ignored.
+                    Materials from <BlockIcon sx={{ display: "inline-block", verticalAlign: "middle", color: "primary.main" }} /> disabled Events are ignored.
                 </li>
             </ul>
         </>;
@@ -600,38 +600,33 @@ const MaterialsSummaryDialog = React.memo((props: Props) => {
                                     }
                                 });
 
-                            // Upgrade craftable flags based on ingredients already in list
-                            const craftableMap = new Map<string, number>(); // matId -> craftable amount
+                            //Update craftable flags based on ingredients already in list
                             currentMaterialsMap.forEach((value, id) => {
                                 let { missing, isCraftable } = value;
                                 if (!isCraftable) return;
 
                                 const matInfo: Item = itemsJson[id as keyof typeof itemsJson];
                                 if (!matInfo.ingredients?.length) {
-                                    // No ingredients -> nothing to check
-                                    craftableMap.set(id, missing);
                                     return;
                                 }
 
                                 // Check each ingredient
                                 for (const ing of matInfo.ingredients) {
                                     const ingInfo: Item = itemsJson[ing.id as keyof typeof itemsJson];
-                                    if (!ingInfo || ingInfo.tier >= matInfo.tier) continue; // only lower-tier ingredients matter
+                                    if (!ingInfo || ingInfo.tier >= matInfo.tier) continue;
 
-                                    const craftableQty = craftableMap.get(ing.id) ?? 0;
-                                    const recipeQty = ing.quantity
-                                    const neededQty = recipeQty * missing; // amount required to craft fully
+                                    const ingredientMissing = currentMaterialsMap.get(ing.id)?.missing ?? 0;
+                                    const craftOneQty = ing.quantity;
+                                    const totalNeeded = craftOneQty * missing;
 
-                                    if ((neededQty - craftableQty) < recipeQty) {
-                                        //means: difference with low tier ingredients is not enough to craft
+                                    if ((totalNeeded - ingredientMissing) < craftOneQty) {
+                                        //not enough for craftOne
                                         isCraftable = false;
+                                        currentMaterialsMap.set(id, { missing, isCraftable });
                                         break;
                                     }
                                 }
-                                currentMaterialsMap.set(id, { missing, isCraftable });
-                                if (isCraftable) craftableMap.set(id, missing);
                             });
-
 
                             if (currentMaterialsMap.size > 0) {
                                 sortedNeedToCraftByOpInGroup.push({

--- a/src/components/planner/goals/CompletionIndicator.tsx
+++ b/src/components/planner/goals/CompletionIndicator.tsx
@@ -3,21 +3,34 @@ import clsx from "clsx";
 
 type Orientation = "vertical" | "horizontal";
 
-interface CompletionIndicatorProps extends BoxProps {
+export interface CompletionIndicatorProps extends BoxProps {
   completable: boolean;
   completableByCrafting: boolean;
-  orientation?: Orientation; 
+  requirementsNotMet?: boolean;
+  orientation?: Orientation;
 }
 
 export function CompletionIndicator({
   completable,
   completableByCrafting,
+  requirementsNotMet = false,
   orientation = "vertical",
   children,
   className,
   ...props
 }: CompletionIndicatorProps) {
-  const status = completable ? "completable" : (completableByCrafting && !completable) ? "craftable" : "none";
+  const status =
+    completable
+      ? "completable"
+      : (completableByCrafting && !completable)
+        ? "craftable"
+        : "none";
+  const backgroundColor =
+    status === "completable"
+      ? "success.main"
+      : status === "craftable"
+        ? "warning.main"
+        : "transparent"
   return (
     <Box
       {...props}
@@ -36,13 +49,21 @@ export function CompletionIndicator({
             bottom: 0,
             width: "2px",
             height: "100%",
-            backgroundColor:
-              status === "completable"
-                ? "success.main"
-                : status === "craftable"
-                ? "warning.main"
-                : "transparent",
+            backgroundColor,
+            zIndex: 1,
           },
+          ...(requirementsNotMet && (completable || completableByCrafting) && {
+            "&:after": {
+              content: '""',
+              position: "absolute",
+              left: 0,
+              top: "35%",
+              width: "2px",
+              height: "30%",
+              backgroundColor: "error.main",
+              zIndex: 2,
+            },
+          }),
         }),
         ...(orientation === "horizontal" && {
           "&:after": {
@@ -52,12 +73,7 @@ export function CompletionIndicator({
             bottom: 0,
             height: "2px",
             width: "70%",
-            backgroundColor:
-              status === "completable"
-                ? "success.main"
-                : status === "craftable"
-                ? "warning.main"
-                : "transparent",
+            backgroundColor,
           },
         }),
         ...props.sx,

--- a/src/components/planner/goals/OperatorGoals.tsx
+++ b/src/components/planner/goals/OperatorGoals.tsx
@@ -19,9 +19,9 @@ import operatorJson from "data/operators";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import { Operator } from "types/operators/operator";
 import imageBase from "util/imageBase";
-import { CompletionIndicator } from "./CompletionIndicator";
+import { CompletionIndicator, CompletionIndicatorProps } from "./CompletionIndicator";
 
-interface Props {
+interface Props extends Pick<CompletionIndicatorProps, 'completable' | 'completableByCrafting'> {
   operator: Operator;
   operatorGoal: GoalData;
   onGoalEdit: (opId: string, groupName: string) => void;
@@ -31,8 +31,6 @@ interface Props {
   children?: React.ReactNode;
   onOpSelect: (opId: string, groupName: string) => void;
   onGoalRefresh: (operatorGoal: GoalData) => void;
-  completable: boolean;
-  completableByCrafting: boolean;
 }
 
 export const OperatorGoals = memo((props: Props) => {
@@ -45,8 +43,7 @@ export const OperatorGoals = memo((props: Props) => {
     children,
     onOpSelect,
     onGoalRefresh,
-    completable,
-    completableByCrafting,
+    ...rest
   } = props;
 
   const [expanded, setExpanded] = useState<boolean>(false);
@@ -160,8 +157,7 @@ export const OperatorGoals = memo((props: Props) => {
               }}
             >
               <CompletionIndicator
-                completable={completable}
-                completableByCrafting={completableByCrafting}
+                {...rest}
                 orientation="vertical"
               >
                 <Image src={imgUrl} width={64} height={64} alt="" />

--- a/src/components/planner/goals/PlannerGoals.tsx
+++ b/src/components/planner/goals/PlannerGoals.tsx
@@ -855,7 +855,7 @@ const PlannerGoals = (props: Props) => {
         </Grid>
         {goals &&
           groups &&
-          groupedGoalsMap?.map(({ groupName, index, operatorGoals, inactiveOps, completableOperators, completableByCraftingOperators }) => (
+          groupedGoalsMap?.map(({ groupName, index, operatorGoals, ...rest }) => (
             <GoalGroup
               key={groupName}
               groupName={groupName}
@@ -871,18 +871,15 @@ const PlannerGoals = (props: Props) => {
               }}
               defaultExpanded={index === 0}
               onRename={onGroupRename}
-              inactiveOps={inactiveOps}
               onOpSelect={handleOpSelect}
               onGroupSelect={toggleGroupOpsInactivity}
               getCheckboxState={getGroupCheckboxState}
-              completableOperators={completableOperators}
-              completableByCraftingOperators={completableByCraftingOperators}
+              {...rest}
             >
-              {operatorGoals.map(({ operatorGoal, plannerGoals, substantial, operator, completable, completableByCrafting }) => (
+              {operatorGoals.map(({ operatorGoal, plannerGoals, substantial, ...rest }) => (
                 <Collapse in={substantial} key={operatorGoal.op_id}>
                   <OperatorGoals
                     key={operatorGoal.op_id}
-                    operator={operator}
                     operatorGoal={operatorGoal}
                     onGoalEdit={onGoalEdit}
                     onGoalMove={onGoalMove}
@@ -890,8 +887,7 @@ const PlannerGoals = (props: Props) => {
                     completeAllGoalsFromOperator={onPlannerGoalGroupCompleteAllGoals}
                     onOpSelect={handleOpSelect}
                     onGoalRefresh={handleGoalRefresh}
-                    completable={completable}
-                    completableByCrafting={completableByCrafting}
+                    {...rest}
                   >
                     {plannerGoals.map((plannerGoal, index) => (
                       <PlannerGoalCard
@@ -902,6 +898,7 @@ const PlannerGoals = (props: Props) => {
                         onGoalCompleted={onPlannerGoalCardGoalCompleted}
                         completable={plannerGoal.completable}
                         completableByCrafting={plannerGoal.completableByCrafting}
+                        requirementsNotMet={plannerGoal.requirementsNotMet}
                         ingredients={plannerGoal.ingredients}
                       />
                     ))}

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -80,9 +80,15 @@ export type PlannerGoal =
   | PlannerModuleGoal
   | PlannerSkillLevelGoal
   | PlannerLevelGoal;
-  
-export type PlannerGoalCalculated = PlannerGoal & {
+
+export type PlannerGoalsSortable = PlannerGoal & {
+  sort_order: number;
+  sort_order_upgrade: number;
+};
+
+export type PlannerGoalCalculated = PlannerGoalsSortable & {
   completable: boolean;
   completableByCrafting: boolean;
+  requirementsNotMet: boolean;
   ingredients: Ingredient[];
-};
+}

--- a/src/util/fns/planner/checkPlannerGoalRequirements.ts
+++ b/src/util/fns/planner/checkPlannerGoalRequirements.ts
@@ -1,0 +1,65 @@
+import operatorJson from "data/operators";
+import { OperatorGoalCategory, PlannerGoal } from "types/goal";
+import { Operator } from "types/operators/operator";
+import { MAX_LEVEL_BY_RARITY, MAX_SKILL_LEVEL_BY_PROMOTION } from "util/changeOperator";
+
+export const checkPlannerGoalRequirements = (goal: PlannerGoal, op: Operator): boolean => {
+
+    const opData = operatorJson[op.op_id];
+    if (!opData) return false;
+    const rarity = opData.rarity;
+
+    switch (goal.category) {
+        //elite - check levels=max for rarity and elite-1
+        case OperatorGoalCategory.Elite: {
+            const prevElite = goal.eliteLevel - 1;
+            if (prevElite < 0) return false;
+            const maxLevelPrevElite = MAX_LEVEL_BY_RARITY[rarity][prevElite];
+            if (maxLevelPrevElite == null) return false;
+            return op.elite === prevElite && op.level >= maxLevelPrevElite;
+        }
+
+        //level - need same elite, and ===fromLevel
+        case OperatorGoalCategory.Level: {
+            return op.elite === goal.eliteLevel && op.level === goal.fromLevel;
+        }
+
+        //skill level - need elite, and skill level-1
+        case OperatorGoalCategory.SkillLevel: {
+            const requiredElite =
+                MAX_SKILL_LEVEL_BY_PROMOTION.findIndex(max => goal.skillLevel <= max);
+            if (requiredElite === -1) return false;
+            return (
+                op.elite >= requiredElite &&
+                op.skill_level === goal.skillLevel - 1
+            );
+        }
+
+        //mastery - needs skill level 7, elite2 and mastery by index-1
+        case OperatorGoalCategory.Mastery: {
+            const opData = operatorJson[goal.operatorId];
+            if (!opData?.skillData) return false;
+            const skillIndex = opData.skillData.findIndex(s => s.skillId === goal.skillId);
+            if (skillIndex === -1) return false;
+
+            return (
+                op.elite === 2 &&
+                op.skill_level === 7 &&
+                op.masteries[skillIndex] === goal.masteryLevel - 1
+            );
+        }
+
+        //module - needs elite 2 and level 60, and module by id-1
+        case OperatorGoalCategory.Module: {
+            const currentModuleLevel = op.modules[goal.moduleId] ?? 0;
+            return (
+                op.elite === 2 &&
+                op.level >= 60 &&
+                currentModuleLevel === goal.moduleLevel - 1
+            );
+        }
+
+        default:
+            return false;
+    }
+};


### PR DESCRIPTION
+type changes & pass sort_orders from goalData > plannerGoal conversion.
+sort by upgrade order for calculations and sort back to fancy look.
+check goal requirements on virtual op, red indication for not met and skip goal.