### PR TITLE
import fixes & instuction & ordered mode tweaks

### DIFF
--- a/src/components/app/GameImport.tsx
+++ b/src/components/app/GameImport.tsx
@@ -155,13 +155,14 @@ const GameImport = memo(() => {
 
         //currently amiya only, if not null operator has class change and must be handled in a custom way
         if (value.tmpl) {
-          for (let key in value.tmpl) {
-            let altValue = value.tmpl[key];
+          for (let altKey in value.tmpl) {
+            let altValue = value.tmpl[altKey];
+            const altOpData = operatorJson[altKey]!;
 
             //first module is the default one, we can skip.
 
             let altSupportModules: Record<string, number> = Object.fromEntries(
-              opData?.moduleData?.map((mod) => [mod.moduleId, 0]) ?? []
+              altOpData?.moduleData?.map((mod) => [mod.moduleId, 0]) ?? []
             );
             Object.entries(altValue.equip)
               .slice(1)
@@ -170,7 +171,7 @@ const GameImport = memo(() => {
 
             let altMasteries = altValue.skills.map((skill) => skill.specializeLevel);
             let skin = altValue.skinId as string | null;
-            const opSkins: Skin[] = skinJson[value.charId as keyof typeof skinJson];
+            const opSkins: Skin[] = skinJson[altKey as keyof typeof skinJson];
             //convert to aceship format
             if (opSkins && skin) {
               const matches = opSkins.filter((x) => x.skinId == skin);
@@ -180,12 +181,12 @@ const GameImport = memo(() => {
             }
 
             let alternativeOperator: Operator = {
-              op_id: key,
+              op_id: altKey,
               elite: value.evolvePhase,
               level: value.level,
               potential: value.potentialRank + 1,
               skill_level: value.mainSkillLvl,
-              favorite: _roster[value.charId]?.favorite || false,
+              favorite: _roster[altKey]?.favorite || false,
               skin: skin,
               modules: altSupportModules,
               masteries: altMasteries,
@@ -363,7 +364,7 @@ const GameImport = memo(() => {
             }
             label="Import Operators"
           />
-         <FormControlLabel
+          <FormControlLabel
             control={
               <Checkbox
                 id="refreshGoals"
@@ -382,7 +383,7 @@ const GameImport = memo(() => {
               />
             }
             label="Update & Clear Planner Goals"
-            sx={{ ml: 1}}
+            sx={{ ml: 1 }}
           />
           <FormControlLabel
             control={

--- a/src/components/planner/depot/MaterialsNeeded.tsx
+++ b/src/components/planner/depot/MaterialsNeeded.tsx
@@ -64,7 +64,7 @@ const MaterialsNeeded = React.memo((props: Props) => {
 
   const { setAnchorEl, menuProps, menuButtonProps } = useMenu();
 
-  const craftToggleTooltips = ["Toggle only craftable materials ON - use with Goals and Filters", "Toggle all crafting states ON", "Reset all crafting states"];
+  const craftToggleTooltips = ["Toggle only craftable materials ON\nto use with Goals and Filters", "Toggle all crafting states ON", "Reset all crafting states"];
   const initialCraftToggle = 1;
   const [craftToggle, setCraftToggle] = useState(initialCraftToggle);
 
@@ -469,7 +469,7 @@ const MaterialsNeeded = React.memo((props: Props) => {
               color="primary">
               Summary
             </Button>
-            <Tooltip arrow title={craftToggleTooltips[craftToggle]}>
+            <Tooltip arrow title={<Typography variant="body1" sx={{whiteSpace: "pre-line"}}>{craftToggleTooltips[craftToggle]}</Typography>}>
               <Button
                 onClick={handleCraftingToggleAll}
                 variant="contained"
@@ -501,11 +501,8 @@ const MaterialsNeeded = React.memo((props: Props) => {
             Show increment/decrement buttons
           </SettingsMenuItem>
           <SettingsMenuItem onClick={handleAllowNoLmdCrafting} checked={settings.depotSettings.ignoreLmdInCrafting}>
-            Ignore LMD in crafting requirements
+            Ignore LMD & Exp in craft and goals
           </SettingsMenuItem>
-          <MenuItem disabled>
-            <ListItemText inset>Allow all &gt; goals menu</ListItemText>
-          </MenuItem>
           <Divider />
           <MenuItem onClick={() => {
             setAnchorEl(null);

--- a/src/components/planner/depot/MaterialsSummaryDialog.tsx
+++ b/src/components/planner/depot/MaterialsSummaryDialog.tsx
@@ -565,10 +565,10 @@ const MaterialsSummaryDialog = React.memo((props: Props) => {
                                 });
                             });
                             // Mutate future depot for hypothetical crafting
-                            canCompleteByCrafting(opInGroupMaterialsNeededFuture, runningFutureDepot, craftingList);
+                            canCompleteByCrafting(opInGroupMaterialsNeededFuture, runningFutureDepot, craftingList, settings.depotSettings.ignoreLmdInCrafting);
 
                             // Mutate current depot & get craftable info
-                            const { craftableItems } = canCompleteByCrafting(opInGroupMaterialsNeededCurrent, runningCurrentDepot, craftingList);
+                            const { craftableItems } = canCompleteByCrafting(opInGroupMaterialsNeededCurrent, runningCurrentDepot, craftingList, settings.depotSettings.ignoreLmdInCrafting);
 
                             // Prepare future & current material lists
                             const futureMaterialsArray: [string, number][] = []; //new Map<string, number>();
@@ -696,7 +696,8 @@ const MaterialsSummaryDialog = React.memo((props: Props) => {
     }, [open, goalsMaterials, depot, expOwned, includeCraftIds, selectedEvent,
         getTier3StatisticFromMaterials,
         addBalanceValue, upcomingMaterialsData, groupedGoalsMap,
-        settings.plannerSettings.calculateGoalsInOrder]
+        settings.plannerSettings.calculateGoalsInOrder,
+        settings.depotSettings.ignoreLmdInCrafting]
     );
 
     const { sortedNeedToFarm, sortedNeedToCraft, sortedNeedToCraftByOpInGroup, sortedPossibleCraft, sortedEventMaterials } = useMemo(calculateSummaryTab, [calculateSummaryTab]);

--- a/src/components/planner/goals/OperatorGoals.tsx
+++ b/src/components/planner/goals/OperatorGoals.tsx
@@ -216,7 +216,19 @@ export const OperatorGoals = memo((props: Props) => {
             <MenuItem component="button" onClick={handleMoveGoalButtonClick}>
               <Typography>Change Group</Typography>
             </MenuItem>
-            <Tooltip title="Force complete and remove. Consume or craft items set to 'Crafting'" arrow describeChild>
+            <Tooltip placement="top" arrow
+              slotProps={{
+                popper: {
+                  modifiers: [{
+                    name: 'offset',
+                    options: { offset: [0, 10], },
+                  },],
+                },
+              }}
+              title={
+                <Typography variant="body2" >
+                  Force complete and remove.<br />Consume or craft items set to 'Crafting'
+                </Typography>} describeChild>
               <MenuItem component="button" onClick={handleCompleteGoalsButtonClick}>
                 <Typography color="success">Complete all goals</Typography>
               </MenuItem>

--- a/src/components/planner/goals/PlannerGoals.tsx
+++ b/src/components/planner/goals/PlannerGoals.tsx
@@ -718,6 +718,14 @@ const PlannerGoals = (props: Props) => {
   }, [updateGoals, roster]
   );
 
+  const handleAllowNoLmdCrafting = useCallback(() => {
+    const depotSettings = { ...settings.depotSettings };
+    depotSettings.ignoreLmdInCrafting = !depotSettings?.ignoreLmdInCrafting;
+
+    setSettings((s) => ({ ...s, depotSettings }));
+    setAnchorEl(null);
+  }, [settings, setSettings, setAnchorEl]);
+
   //once on page-load > after useEffects from useOps useGoals
   useEffect(() => {
     if (settings.plannerSettings.autoRefreshGoals ?? true) {
@@ -739,6 +747,9 @@ const PlannerGoals = (props: Props) => {
             <SettingsMenu props={menuProps}>
               <SettingsMenuItem onClick={handleAllowAllGoals} checked={settings.plannerSettings.allowAllGoals}>
                 Allow completing goals unconditionally
+              </SettingsMenuItem>
+              <SettingsMenuItem onClick={handleAllowNoLmdCrafting} checked={settings.depotSettings.ignoreLmdInCrafting}>
+                Ignore LMD & Exp in craft and goals
               </SettingsMenuItem>
               <SettingsMenuItem
                 onClick={handleSortEmptyGroupsToBottom}
@@ -812,7 +823,10 @@ const PlannerGoals = (props: Props) => {
           }}
         >
           <Grid>
-            <Tooltip title="Calculate goals in descending order">
+            <Tooltip title={
+              <Typography variant="body1">Calculate goals from top op to bottom,
+                <br />following required upgrade order</Typography>
+            }>
               <IconButton size="large" onClick={handleCalculateGoalsInOrder}
                 color={(settings.plannerSettings?.calculateGoalsInOrder ?? true) ? "primary" : "default"}>
                 <LowPriorityIcon fontSize="inherit" />
@@ -892,14 +906,10 @@ const PlannerGoals = (props: Props) => {
                     {plannerGoals.map((plannerGoal, index) => (
                       <PlannerGoalCard
                         key={index}
-                        goal={plannerGoal}
                         groupName={groupName}
                         onGoalDeleted={onPlannerGoalCardGoalDeleted}
                         onGoalCompleted={onPlannerGoalCardGoalCompleted}
-                        completable={plannerGoal.completable}
-                        completableByCrafting={plannerGoal.completableByCrafting}
-                        requirementsNotMet={plannerGoal.requirementsNotMet}
-                        ingredients={plannerGoal.ingredients}
+                        {...plannerGoal}
                       />
                     ))}
                   </OperatorGoals>

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -90,5 +90,6 @@ export type PlannerGoalCalculated = PlannerGoalsSortable & {
   completable: boolean;
   completableByCrafting: boolean;
   requirementsNotMet: boolean;
+  available: boolean;
   ingredients: Ingredient[];
 }

--- a/src/util/fns/planner/calculateCompletableStatus.ts
+++ b/src/util/fns/planner/calculateCompletableStatus.ts
@@ -9,10 +9,12 @@ import expToBattleRecords from "../depot/expToBattleRecords";
 import { Ingredient } from "types/item";
 
 const calculateCompletableStatus = (plannerGoal: PlannerGoal, depot: Record<string, DepotItem>, settings: LocalStorageSettings) => {
-    if (settings.plannerSettings.allowAllGoals) {
+    if (settings.plannerSettings.allowAllGoals
+        || (settings.depotSettings.ignoreLmdInCrafting && plannerGoal.category === OperatorGoalCategory.Level) //ignore lmd & exp
+    ) {
         return { completable: true, completableByCrafting: false, depot, ingredients: getGoalIngredients(plannerGoal) };
     }
-    let depotUpdate: Record<string,DepotItem>;
+    let depotUpdate: Record<string, DepotItem>;
     let completable = false;
     let completableByCrafting = false;
     let ingredients: Ingredient[];
@@ -24,14 +26,14 @@ const calculateCompletableStatus = (plannerGoal: PlannerGoal, depot: Record<stri
             plannerGoal.eliteLevel,
             plannerGoal.toLevel
         );
-        ingredients = [{id:"4001",quantity:lmd},{id:"EXP",quantity:exp}];
+        ingredients = [{ id: "4001", quantity: lmd }, { id: "EXP", quantity: exp }];
         const { success, depot: _depot } = expToBattleRecords(exp, depot);
         _depot["4001"].stock = Math.max(0, _depot["4001"].stock - lmd);
 
         completableByCrafting = false;
         completable = success
-            && (depot["4001"].stock >= lmd || settings.depotSettings.ignoreLmdInCrafting);        
-        
+            && (depot["4001"].stock >= lmd || settings.depotSettings.ignoreLmdInCrafting);
+
         depotUpdate = completable ? _depot : depot;
     } else {
         ingredients = getGoalIngredients(plannerGoal);


### PR DESCRIPTION
import:
-Amiya skins&modules fixes
-handle lvl1 account as error, show added fix instuctions.
-remove warnings and confirmations for lvl5+ users. Show only to new users before successfull import.

goals - better tooltips for ordered mode:
-specified requirements, more coherent texts, point to ordered mode button.
-IgnoreLmd also ignores Exp and Level goals
-keep disabled complete button disabled with added future materials.